### PR TITLE
Fix token counting for tool call and tool response events in compaction strategies

### DIFF
--- a/docs/session-management/compaction.md
+++ b/docs/session-management/compaction.md
@@ -83,6 +83,27 @@ Strategies implement `CompactionStrategy` (a `@FunctionalInterface`) and define 
 do with the event history. Each strategy receives a `CompactionRequest` containing the
 session metadata and the full event list.
 
+### Token accounting
+
+All four strategies estimate the token cost of archived events using the same event
+formatter. Tool calls and tool responses contribute their full formatted representation —
+not just the raw `getText()` content, which is `null` for both types.
+
+| Message type | Formatted as |
+|---|---|
+| `UserMessage` / `AssistantMessage` / `SystemMessage` | `User: <text>` / `Assistant: <text>` / `System: <text>` |
+| `AssistantMessage` with tool calls | `Assistant [tool calls: name(args), ...]` |
+| `ToolResponseMessage` | `Tool [responses: name -> data, ...]` |
+
+This ensures `tokensEstimatedSaved` in `CompactionResult` accurately reflects the full
+cost of removed events, including tool-heavy turns.
+
+`RecursiveSummarizationCompactionStrategy` uses the same formatter when building the
+summarization prompt sent to the LLM, and exposes an `eventFormatter` builder option to
+override it (see below).
+
+---
+
 ### SlidingWindowCompactionStrategy
 
 Keeps the last `N` **real** events. Simple, predictable, no LLM call required. Synthetic
@@ -141,10 +162,11 @@ TokenCountCompactionStrategy.builder().maxTokens(4000).tokenCountEstimator(myEst
 **Algorithm**
 
 1. Separate synthetic events (their token cost is deducted from the budget first).
-2. Walk real events from newest to oldest, accumulating token cost. Stop at the first
-   event that would exceed the remaining budget. This produces a **contiguous suffix** —
-   skipping individual oversize events would create non-contiguous gaps that break
-   conversation coherence.
+2. Walk real events from newest to oldest, accumulating token cost (estimated via the
+   shared event formatter — see [Token accounting](#token-accounting) above). Stop at the
+   first event that would exceed the remaining budget. This produces a **contiguous
+   suffix** — skipping individual oversize events would create non-contiguous gaps that
+   break conversation coherence.
 3. Drop any leading kept events that are not `USER` messages (turn-boundary safety).
 4. Return: `[synthetics] + [kept events]`.
 
@@ -163,6 +185,7 @@ RecursiveSummarizationCompactionStrategy strategy =
         .systemPrompt("...")           // optional custom system prompt
         .shadowPrompt("...")           // optional custom USER shadow prompt
         .tokenCountEstimator(myEst)   // custom estimator (default: JTokkitTokenCountEstimator)
+        .eventFormatter(myFormatter)  // optional custom event-to-text renderer (see below)
         .build();
 ```
 
@@ -183,6 +206,24 @@ RecursiveSummarizationCompactionStrategy strategy =
         .onSummarizationFailure(req -> {
             log.error("Compaction failed for session {}", req.session().id());
             // retry, alert, increment a metric, etc.
+        })
+        .build();
+```
+
+**Custom event formatter**
+
+The strategy uses the shared event formatter (see [Token accounting](#token-accounting))
+when building the summarization prompt, so tool call names, arguments, and response data
+are all visible to the LLM. Override it via `eventFormatter` for domain-specific rendering
+or multilingual summaries:
+
+```java
+RecursiveSummarizationCompactionStrategy strategy =
+    RecursiveSummarizationCompactionStrategy.builder(chatClient)
+        .maxEventsToKeep(10)
+        .eventFormatter(event -> switch (event.getMessageType()) {
+            case TOOL -> "Tool result: " + event.getMessage().getText();
+            default   -> RecursiveSummarizationCompactionStrategy.formatEvent(event);
         })
         .build();
 ```

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/CompactionUtils.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/CompactionUtils.java
@@ -17,8 +17,11 @@
 package org.springframework.ai.session.compaction;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.session.SessionEvent;
 
 /**
@@ -30,6 +33,50 @@ import org.springframework.ai.session.SessionEvent;
 final class CompactionUtils {
 
 	private CompactionUtils() {
+	}
+
+	/**
+	 * Renders a {@link SessionEvent} as a single line of text suitable for token
+	 * estimation and LLM summarization prompts.
+	 *
+	 * <p>
+	 * Handles all Spring AI message types:
+	 * <ul>
+	 * <li>Plain user / assistant / system messages → {@code "Role: text"}</li>
+	 * <li>{@link AssistantMessage} with tool calls → {@code "Assistant [tool calls: name(args), ...]"}</li>
+	 * <li>{@link ToolResponseMessage} → {@code "Tool [responses: name -> data, ...]"}</li>
+	 * </ul>
+	 * @param event the session event to format
+	 * @return a non-null, non-empty string representing the event
+	 */
+	static String formatEvent(SessionEvent event) {
+		String role = switch (event.getMessageType()) {
+			case USER -> "User";
+			case ASSISTANT -> "Assistant";
+			case SYSTEM -> "System";
+			case TOOL -> "Tool";
+		};
+
+		if (event.getMessage() instanceof AssistantMessage am && am.hasToolCalls()) {
+			String calls = am.getToolCalls()
+				.stream()
+				.map(tc -> tc.name() + "(" + tc.arguments() + ")")
+				.collect(Collectors.joining(", "));
+			String text = am.getText();
+			return (text != null && !text.isBlank()) ? role + ": " + text + " [tool calls: " + calls + "]"
+					: role + " [tool calls: " + calls + "]";
+		}
+
+		if (event.getMessage() instanceof ToolResponseMessage trm) {
+			String responses = trm.getResponses()
+				.stream()
+				.map(r -> r.name() + " -> " + r.responseData())
+				.collect(Collectors.joining(", "));
+			return role + " [responses: " + responses + "]";
+		}
+
+		String text = event.getMessage().getText();
+		return role + ": " + (text != null ? text : "[no text content]");
 	}
 
 	/**

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/RecursiveSummarizationCompactionStrategy.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/RecursiveSummarizationCompactionStrategy.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -114,9 +115,12 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 
 	@Nullable private final Consumer<CompactionRequest> onSummarizationFailure;
 
+	private final Function<SessionEvent, String> eventFormatter;
+
 	private RecursiveSummarizationCompactionStrategy(ChatClient chatClient, int maxEventsToKeep, int overlapSize,
 			String systemPrompt, String shadowPrompt, TokenCountEstimator tokenCountEstimator,
-			@Nullable Consumer<CompactionRequest> onSummarizationFailure) {
+			@Nullable Consumer<CompactionRequest> onSummarizationFailure,
+			Function<SessionEvent, String> eventFormatter) {
 		Assert.notNull(chatClient, "chatClient must not be null");
 		Assert.isTrue(maxEventsToKeep > 0, "maxEventsToKeep must be greater than 0");
 		Assert.isTrue(overlapSize >= 0, "overlapSize must be >= 0");
@@ -124,6 +128,7 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 		Assert.hasText(systemPrompt, "systemPrompt must not be empty");
 		Assert.hasText(shadowPrompt, "shadowPrompt must not be empty");
 		Assert.notNull(tokenCountEstimator, "tokenCountEstimator must not be null");
+		Assert.notNull(eventFormatter, "eventFormatter must not be null");
 		this.chatClient = chatClient;
 		this.maxEventsToKeep = maxEventsToKeep;
 		this.overlapSize = overlapSize;
@@ -131,6 +136,7 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 		this.shadowPrompt = shadowPrompt;
 		this.tokenCountEstimator = tokenCountEstimator;
 		this.onSummarizationFailure = onSummarizationFailure;
+		this.eventFormatter = eventFormatter;
 	}
 
 	@Override
@@ -215,9 +221,7 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 		List<SessionEvent> archived = new ArrayList<>(toArchive);
 
 		int tokensArchived = toArchive.stream()
-			.map(e -> e.getMessage().getText())
-			.filter(t -> t != null)
-			.mapToInt(this.tokenCountEstimator::estimate)
+			.mapToInt(e -> this.tokenCountEstimator.estimate(this.eventFormatter.apply(e)))
 			.sum();
 
 		return new CompactionResult(compacted, archived, tokensArchived);
@@ -248,26 +252,19 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 		}
 
 		prompt.append("=== CONVERSATION TO SUMMARIZE ===\n");
-		eventsToSummarize.forEach(e -> prompt.append(formatEvent(e)).append("\n"));
+		eventsToSummarize.forEach(e -> prompt.append(this.eventFormatter.apply(e)).append("\n"));
 
 		if (!overlapEvents.isEmpty()) {
 			prompt.append("\n=== UPCOMING CONTEXT (do not summarize — for continuity only) ===\n");
-			overlapEvents.forEach(e -> prompt.append(formatEvent(e)).append("\n"));
+			overlapEvents.forEach(e -> prompt.append(this.eventFormatter.apply(e)).append("\n"));
 		}
 
 		prompt.append("\nPlease write the summary now:");
 		return prompt.toString();
 	}
 
-	private static String formatEvent(SessionEvent event) {
-		String role = switch (event.getMessageType()) {
-			case USER -> "User";
-			case ASSISTANT -> "Assistant";
-			case SYSTEM -> "System";
-			case TOOL -> "Tool";
-		};
-		String text = event.getMessage().getText();
-		return role + ": " + (text != null ? text : "[no text content]");
+	public static String formatEvent(SessionEvent event) {
+		return CompactionUtils.formatEvent(event);
 	}
 
 	// --- Builder ---
@@ -291,6 +288,8 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 		private TokenCountEstimator tokenCountEstimator = new JTokkitTokenCountEstimator();
 
 		@Nullable private Consumer<CompactionRequest> onSummarizationFailure;
+
+		private Function<SessionEvent, String> eventFormatter = RecursiveSummarizationCompactionStrategy::formatEvent;
 
 		private Builder(ChatClient chatClient) {
 			Assert.notNull(chatClient, "chatClient must not be null");
@@ -362,13 +361,25 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 			return this;
 		}
 
+		/**
+		 * Overrides the function used to render a {@link SessionEvent} as a line of text in
+		 * the summarization prompt and for token counting. Defaults to the built-in
+		 * formatter which handles plain text, tool calls, and tool responses.
+		 */
+		public Builder eventFormatter(Function<SessionEvent, String> eventFormatter) {
+			Assert.notNull(eventFormatter, "eventFormatter must not be null");
+			this.eventFormatter = eventFormatter;
+			return this;
+		}
+
 		public RecursiveSummarizationCompactionStrategy build() {
 			if (this.overlapSize >= this.maxEventsToKeep) {
 				throw new IllegalArgumentException("overlapSize (" + this.overlapSize
 						+ ") must be less than maxEventsToKeep (" + this.maxEventsToKeep + ")");
 			}
 			return new RecursiveSummarizationCompactionStrategy(this.chatClient, this.maxEventsToKeep, this.overlapSize,
-					this.systemPrompt, this.shadowPrompt, this.tokenCountEstimator, this.onSummarizationFailure);
+					this.systemPrompt, this.shadowPrompt, this.tokenCountEstimator, this.onSummarizationFailure,
+					this.eventFormatter);
 		}
 
 	}

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategy.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategy.java
@@ -100,9 +100,7 @@ public final class SlidingWindowCompactionStrategy implements CompactionStrategy
 		compacted.addAll(keptReal);
 
 		int tokensRemoved = removedReal.stream()
-			.map(e -> e.getMessage().getText())
-			.filter(t -> t != null)
-			.mapToInt(this.tokenCountEstimator::estimate)
+			.mapToInt(e -> this.tokenCountEstimator.estimate(CompactionUtils.formatEvent(e)))
 			.sum();
 
 		return new CompactionResult(compacted, removedReal, tokensRemoved);

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategy.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategy.java
@@ -81,9 +81,7 @@ public final class TokenCountCompactionStrategy implements CompactionStrategy {
 		List<SessionEvent> real = events.stream().filter(e -> !e.isSynthetic()).toList();
 
 		int syntheticTokens = synthetic.stream()
-			.map(e -> e.getMessage().getText())
-			.filter(t -> t != null)
-			.mapToInt(t -> this.tokenCountEstimator.estimate(t))
+			.mapToInt(e -> this.tokenCountEstimator.estimate(CompactionUtils.formatEvent(e)))
 			.sum();
 
 		int remainingBudget = this.maxTokens - syntheticTokens;
@@ -95,8 +93,7 @@ public final class TokenCountCompactionStrategy implements CompactionStrategy {
 		int cutIndex = real.size();
 		int usedTokens = 0;
 		for (int i = real.size() - 1; i >= 0; i--) {
-			String text = real.get(i).getMessage().getText();
-			int tokens = (text != null) ? this.tokenCountEstimator.estimate(text) : 0;
+			int tokens = this.tokenCountEstimator.estimate(CompactionUtils.formatEvent(real.get(i)));
 			if (usedTokens + tokens <= remainingBudget) {
 				usedTokens += tokens;
 				cutIndex = i;
@@ -125,9 +122,7 @@ public final class TokenCountCompactionStrategy implements CompactionStrategy {
 		compacted.addAll(kept);
 
 		int tokensRemoved = archived.stream()
-			.map(e -> e.getMessage().getText())
-			.filter(t -> t != null)
-			.mapToInt(t -> this.tokenCountEstimator.estimate(t))
+			.mapToInt(e -> this.tokenCountEstimator.estimate(CompactionUtils.formatEvent(e)))
 			.sum();
 
 		return new CompactionResult(compacted, archived, tokensRemoved);

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategy.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategy.java
@@ -114,9 +114,7 @@ public final class TurnWindowCompactionStrategy implements CompactionStrategy {
 		compacted.addAll(kept);
 
 		int tokensArchived = archived.stream()
-			.map(e -> e.getMessage().getText())
-			.filter(t -> t != null)
-			.mapToInt(this.tokenCountEstimator::estimate)
+			.mapToInt(e -> this.tokenCountEstimator.estimate(CompactionUtils.formatEvent(e)))
 			.sum();
 
 		return new CompactionResult(compacted, archived, tokensArchived);

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/RecursiveSummarizationCompactionStrategyTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/RecursiveSummarizationCompactionStrategyTests.java
@@ -27,9 +27,12 @@ import org.mockito.Answers;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.content.MediaContent;
 import org.springframework.ai.session.Session;
 import org.springframework.ai.session.SessionEvent;
+import org.springframework.ai.tokenizer.TokenCountEstimator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -419,7 +422,121 @@ class RecursiveSummarizationCompactionStrategyTests {
 		assertThat(strategy).isNotNull();
 	}
 
+	// --- tool call / tool response formatting ---
+
+	@Test
+	void toolCallNamesAndArgumentsAppearInFormattedOutput() {
+		List<String> estimatedTexts = new ArrayList<>();
+		TokenCountEstimator capturingEstimator = capturingEstimator(estimatedTexts);
+
+		RecursiveSummarizationCompactionStrategy strategy = RecursiveSummarizationCompactionStrategy
+			.builder(this.chatClient)
+			.maxEventsToKeep(2)
+			.overlapSize(0)
+			.tokenCountEstimator(capturingEstimator)
+			.build();
+
+		strategy.compact(contextFor(buildToolCallSession()));
+
+		// The capturing estimator receives the output of formatEvent() for each archived
+		// event, so tool call names and arguments must appear in at least one entry.
+		assertThat(estimatedTexts).anyMatch(t -> t.contains("get_weather"));
+		assertThat(estimatedTexts).anyMatch(t -> t.contains("Paris"));
+	}
+
+	@Test
+	void toolResponseContentAppearsInFormattedOutput() {
+		List<String> estimatedTexts = new ArrayList<>();
+
+		RecursiveSummarizationCompactionStrategy strategy = RecursiveSummarizationCompactionStrategy
+			.builder(this.chatClient)
+			.maxEventsToKeep(2)
+			.overlapSize(0)
+			.tokenCountEstimator(capturingEstimator(estimatedTexts))
+			.build();
+
+		strategy.compact(contextFor(buildToolCallSession()));
+
+		assertThat(estimatedTexts).anyMatch(t -> t.contains("22C"));
+	}
+
+	@Test
+	void tokensEstimatedSavedIsPositiveWhenArchivingToolEvents() {
+		RecursiveSummarizationCompactionStrategy strategy = RecursiveSummarizationCompactionStrategy
+			.builder(this.chatClient)
+			.maxEventsToKeep(2)
+			.overlapSize(0)
+			.build();
+
+		CompactionResult result = strategy.compact(contextFor(buildToolCallSession()));
+
+		assertThat(result.tokensEstimatedSaved()).isGreaterThan(0);
+	}
+
+	@Test
+	void customEventFormatterIsApplied() {
+		List<String> estimatedTexts = new ArrayList<>();
+
+		RecursiveSummarizationCompactionStrategy strategy = RecursiveSummarizationCompactionStrategy
+			.builder(this.chatClient)
+			.maxEventsToKeep(2)
+			.overlapSize(0)
+			.tokenCountEstimator(capturingEstimator(estimatedTexts))
+			.eventFormatter(e -> "CUSTOM[" + e.getMessageType() + "]")
+			.build();
+
+		strategy.compact(contextFor(buildRealEvents(4)));
+
+		assertThat(estimatedTexts).isNotEmpty();
+		assertThat(estimatedTexts).allMatch(t -> t.startsWith("CUSTOM["));
+	}
+
 	// --- helpers ---
+
+	/**
+	 * Turn 1 (archived when maxEventsToKeep=2): user question + assistant tool call +
+	 * tool response. Turn 2 (active window): plain user+assistant exchange.
+	 */
+	private List<SessionEvent> buildToolCallSession() {
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("What's the weather?")).build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(AssistantMessage.builder()
+				.toolCalls(List.of(
+						new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"location\":\"Paris\"}")))
+				.build())
+			.build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(ToolResponseMessage.builder()
+				.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "get_weather", "{\"temp\":\"22C\"}")))
+				.build())
+			.build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("Thanks")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("You're welcome")).build());
+		return events;
+	}
+
+	private static TokenCountEstimator capturingEstimator(List<String> sink) {
+		return new TokenCountEstimator() {
+			@Override
+			public int estimate(String text) {
+				sink.add(text);
+				return text.length();
+			}
+
+			@Override
+			public int estimate(MediaContent content) {
+				return 0;
+			}
+
+			@Override
+			public int estimate(Iterable<MediaContent> messages) {
+				return 0;
+			}
+		};
+	}
 
 	private List<SessionEvent> buildRealEvents(int count) {
 		List<SessionEvent> events = new ArrayList<>();

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategyTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategyTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.session.Session;
 import org.springframework.ai.session.SessionEvent;
@@ -190,6 +191,35 @@ class SlidingWindowCompactionStrategyTests {
 			SessionEvent first = result.compactedEvents().get(0);
 			assertThat(first.isSynthetic() || first.getMessage() instanceof UserMessage).isTrue();
 		}
+	}
+
+	@Test
+	void tokensEstimatedSavedIsPositiveWhenArchivingToolEvents() {
+		SlidingWindowCompactionStrategy strategy = SlidingWindowCompactionStrategy.builder().maxEvents(2).build();
+
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(
+				SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("What's the weather?")).build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(AssistantMessage.builder()
+				.toolCalls(List
+					.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"location\":\"Paris\"}")))
+				.build())
+			.build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(ToolResponseMessage.builder()
+				.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "get_weather", "{\"temp\":\"22C\"}")))
+				.build())
+			.build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("Thanks")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("You're welcome")).build());
+
+		CompactionResult result = strategy.compact(contextFor(events));
+
+		assertThat(result.archivedEvents()).isNotEmpty();
+		assertThat(result.tokensEstimatedSaved()).isGreaterThan(0);
 	}
 
 	private List<SessionEvent> buildRealEvents(int count) {

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategyTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategyTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.content.MediaContent;
 import org.springframework.ai.session.Session;
@@ -76,12 +77,11 @@ class TokenCountCompactionStrategyTests {
 
 	@Test
 	void archivesEventsExceedingBudget() {
-		// Each event costs exactly its text length in tokens.
-		// Budget = 4 tokens. Turn1 = "u1"(2) + "a1"(2) = 4 tokens.
-		// Turn2 = "u2"(2) + "a2"(2) = 4 tokens.
-		// Total = 8 tokens; budget = 4 → keep only the newest 4 tokens (turn2).
+		// CHAR_ESTIMATOR counts formatted-text characters (formatEvent output), not raw
+		// getText() lengths. "User: u1"(8) + "Assistant: a1"(13) = 21 per turn.
+		// Budget = 25 → turn2 fits (21 ≤ 25) but turn1+turn2 does not (42 > 25).
 		TokenCountCompactionStrategy strategy = TokenCountCompactionStrategy.builder()
-			.maxTokens(4)
+			.maxTokens(25)
 			.tokenCountEstimator(CHAR_ESTIMATOR)
 			.build();
 		CompactionRequest request = requestWith(turn("u1", "a1"), turn("u2", "a2"));
@@ -98,26 +98,24 @@ class TokenCountCompactionStrategyTests {
 	 * Verifies that scanning stops at the first oversize event so the kept window is a
 	 * contiguous suffix, not a sparse selection of individually-fitting events.
 	 * <p>
-	 * Events (newest-to-oldest scan): u2(2) fits; a1_huge(24) exceeds budget → stop.
-	 * Kept: [u2]. Archived: [u1, a1_huge]. u2 is a USER event so no turn-boundary snap is
-	 * needed.
+	 * Formatted costs: "User: u2"(8) fits in budget 10; "Assistant: a1_very_large_text_here"(34)
+	 * would exceed it → scan stops. Kept: [u2]. Archived: [u1, a1_huge]. u2 is a USER
+	 * event so no turn-boundary snap is needed.
 	 */
 	@Test
 	void stopsAtFirstOversizeEventKeepsContiguousSuffix() {
 		TokenCountCompactionStrategy strategy = TokenCountCompactionStrategy.builder()
-			.maxTokens(6)
+			.maxTokens(10)
 			.tokenCountEstimator(CHAR_ESTIMATOR)
 			.build();
 
 		List<SessionEvent> events = new ArrayList<>();
-		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u1")).build()); // 2
-																											// tokens
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u1")).build()); // 8 tokens
 		events.add(SessionEvent.builder()
 			.sessionId(SESSION_ID)
 			.message(new AssistantMessage("a1_very_large_text_here"))
-			.build()); // 24 tokens — stops scan
-		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u2")).build()); // 2
-																											// tokens
+			.build()); // 34 tokens — stops scan
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u2")).build()); // 8 tokens
 
 		CompactionResult result = strategy.compact(requestWith(events));
 
@@ -250,6 +248,45 @@ class TokenCountCompactionStrategyTests {
 
 		assertThat(result.compactedEvents()).isEmpty();
 		assertThat(result.archivedEvents()).isEmpty();
+	}
+
+	// --- tool call / tool response token counting ---
+
+	@Test
+	void toolEventsCountTowardBudget() {
+		// Budget = 40 chars (CHAR_ESTIMATOR: 1 char = 1 token).
+		// Formatted tool-call and tool-response texts are ~45-55 chars each, which
+		// pushes the total over the 40-token limit and forces archiving turn 1.
+		// Before the fix, both events returned null from getText() and cost 0 tokens,
+		// so the entire session was kept without archiving anything.
+		TokenCountCompactionStrategy strategy = TokenCountCompactionStrategy.builder()
+			.maxTokens(40)
+			.tokenCountEstimator(CHAR_ESTIMATOR)
+			.build();
+
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(
+				SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("What's the weather?")).build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(AssistantMessage.builder()
+				.toolCalls(List
+					.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"location\":\"Paris\"}")))
+				.build())
+			.build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(ToolResponseMessage.builder()
+				.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "get_weather", "{\"temp\":\"22C\"}")))
+				.build())
+			.build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("Thanks")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("You're welcome")).build());
+
+		CompactionResult result = strategy.compact(requestWith(events));
+
+		assertThat(result.archivedEvents()).isNotEmpty();
+		assertThat(result.tokensEstimatedSaved()).isGreaterThan(0);
 	}
 
 	// --- helpers ---

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategyTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategyTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.session.Session;
 import org.springframework.ai.session.SessionEvent;
@@ -243,6 +244,36 @@ class TurnWindowCompactionStrategyTests {
 		CompactionResult result = strategy.compact(request);
 
 		assertThat(result.tokensEstimatedSaved()).isGreaterThanOrEqualTo(0);
+	}
+
+	@Test
+	void tokensEstimatedSavedIsPositiveWhenArchivingTurnWithToolEvents() {
+		TurnWindowCompactionStrategy strategy = TurnWindowCompactionStrategy.builder().maxTurns(1).build();
+
+		// Turn 1 (archived): user question + assistant tool call + tool response
+		List<SessionEvent> toolTurn = new ArrayList<>();
+		toolTurn.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new UserMessage("What's the weather?"))
+			.build());
+		toolTurn.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(AssistantMessage.builder()
+				.toolCalls(List
+					.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"location\":\"Paris\"}")))
+				.build())
+			.build());
+		toolTurn.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(ToolResponseMessage.builder()
+				.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "get_weather", "{\"temp\":\"22C\"}")))
+				.build())
+			.build());
+
+		CompactionResult result = strategy.compact(requestWith(toolTurn, turn("Thanks", "You're welcome")));
+
+		assertThat(result.archivedEvents()).isNotEmpty();
+		assertThat(result.tokensEstimatedSaved()).isGreaterThan(0);
 	}
 
 	// --- helpers ---


### PR DESCRIPTION
All four compaction strategies called getMessage().getText() to estimate token costs, which returns null for AssistantMessage with tool calls and ToolResponseMessage. This caused tool-heavy turns to contribute 0 tokens to tokensEstimatedSaved and RecursiveSummarizationCompactionStrategy to omit tool interactions from the LLM summarization prompt.

Introduce CompactionUtils.formatEvent() as the shared canonical formatter and update all strategies to use it. RecursiveSummarizationCompactionStrategy exposes it as a public static method and adds an eventFormatter builder option for custom rendering.

Closes #2