### PR TITLE
Fix MySQL branch filter broken by || operator

### DIFF
--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
@@ -283,7 +283,7 @@ public final class JdbcSessionRepository implements SessionRepository {
 		if (filter.branch() != null) {
 			// Visibility: null branch (root events) OR exact match OR caller is a
 			// descendant (filterBranch starts with eventBranch + '.')
-			sql.append("AND (e.branch IS NULL OR e.branch = ? OR ? LIKE e.branch || '.%') ");
+			sql.append(this.dialect.getBranchFilterFragment());
 			params.add(filter.branch());
 			params.add(filter.branch());
 		}

--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryDialect.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryDialect.java
@@ -72,6 +72,22 @@ public interface JdbcSessionRepositoryDialect {
 	String getKeywordFilterFragment();
 
 	/**
+	 * Branch visibility filter fragment for multi-agent event isolation. The clause
+	 * matches events that are visible to the given branch: root events (null branch),
+	 * exact branch match, or ancestor branches (the caller is a descendant).
+	 *
+	 * <p>
+	 * The fragment must be a complete {@code AND (...)} clause with two {@code ?}
+	 * placeholders, both bound to the filter branch value. The default implementation
+	 * uses {@code ||} for string concatenation (PostgreSQL / H2). MySQL/MariaDB must
+	 * override this with {@code CONCAT()} because {@code ||} is logical OR in those
+	 * databases.
+	 */
+	default String getBranchFilterFragment() {
+		return "AND (e.branch IS NULL OR e.branch = ? OR ? LIKE e.branch || '.%') ";
+	}
+
+	/**
 	 * Detects the best-matching dialect for the given {@link DataSource}.
 	 */
 	static JdbcSessionRepositoryDialect from(DataSource dataSource) {

--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/MysqlJdbcSessionRepositoryDialect.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/MysqlJdbcSessionRepositoryDialect.java
@@ -40,9 +40,14 @@ public class MysqlJdbcSessionRepositoryDialect implements JdbcSessionRepositoryD
 	@Override
 	public String getKeywordFilterFragment() {
 		// MySQL LIKE is case-insensitive for most collations; LOWER() is still applied
-		// for
-		// safety with binary collations.
+		// for safety with binary collations.
 		return "AND LOWER(COALESCE(e.message_content, '')) LIKE ?";
+	}
+
+	@Override
+	public String getBranchFilterFragment() {
+		// || is logical OR in MySQL/MariaDB; use CONCAT() for string concatenation.
+		return "AND (e.branch IS NULL OR e.branch = ? OR ? LIKE CONCAT(e.branch, '.%')) ";
 	}
 
 }

--- a/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryDialectTests.java
+++ b/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryDialectTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link JdbcSessionRepositoryDialect} implementations, focusing on
+ * SQL correctness for dialect-specific fragments.
+ */
+class JdbcSessionRepositoryDialectTests {
+
+	// -------------------------------------------------------------------------
+	// getBranchFilterFragment — PostgreSQL / H2 (default)
+	// -------------------------------------------------------------------------
+
+	@Test
+	void postgresBranchFilterUsesDoublePipeConcat() {
+		String fragment = new PostgresJdbcSessionRepositoryDialect().getBranchFilterFragment();
+		assertThat(fragment).contains("||");
+		assertThat(fragment).contains("e.branch IS NULL");
+		assertThat(fragment).contains("e.branch = ?");
+	}
+
+	@Test
+	void h2BranchFilterUsesDoublePipeConcat() {
+		String fragment = new H2JdbcSessionRepositoryDialect().getBranchFilterFragment();
+		assertThat(fragment).contains("||");
+		assertThat(fragment).contains("e.branch IS NULL");
+		assertThat(fragment).contains("e.branch = ?");
+	}
+
+	// -------------------------------------------------------------------------
+	// getBranchFilterFragment — MySQL / MariaDB
+	// -------------------------------------------------------------------------
+
+	@Test
+	void mysqlBranchFilterUsesConcatFunction() {
+		String fragment = new MysqlJdbcSessionRepositoryDialect().getBranchFilterFragment();
+		assertThat(fragment).containsIgnoringCase("CONCAT(");
+		assertThat(fragment).contains("e.branch IS NULL");
+		assertThat(fragment).contains("e.branch = ?");
+	}
+
+	@Test
+	void mysqlBranchFilterDoesNotUseDoublePipe() {
+		// || is logical OR in MySQL — using it would silently return wrong results
+		String fragment = new MysqlJdbcSessionRepositoryDialect().getBranchFilterFragment();
+		assertThat(fragment).doesNotContain("||");
+	}
+
+	@Test
+	void mysqlBranchFilterHasTwoPlaceholders() {
+		String fragment = new MysqlJdbcSessionRepositoryDialect().getBranchFilterFragment();
+		long count = fragment.chars().filter(c -> c == '?').count();
+		assertThat(count).as("branch filter must bind two parameters (exact match + LIKE)").isEqualTo(2);
+	}
+
+	// -------------------------------------------------------------------------
+	// Default method contract — all dialects must have two placeholders
+	// -------------------------------------------------------------------------
+
+	@Test
+	void allDialectsBranchFilterHaveTwoPlaceholders() {
+		for (JdbcSessionRepositoryDialect dialect : new JdbcSessionRepositoryDialect[] {
+				new PostgresJdbcSessionRepositoryDialect(),
+				new H2JdbcSessionRepositoryDialect(),
+				new MysqlJdbcSessionRepositoryDialect() }) {
+			String fragment = dialect.getBranchFilterFragment();
+			long count = fragment.chars().filter(c -> c == '?').count();
+			assertThat(count)
+				.as("dialect %s must bind exactly two parameters", dialect.getClass().getSimpleName())
+				.isEqualTo(2);
+		}
+	}
+
+}

--- a/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
+++ b/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
@@ -69,6 +69,9 @@ class JdbcSessionRepositoryTests {
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
+	@Autowired
+	private DataSource dataSource;
+
 	@BeforeEach
 	void cleanUp() {
 		this.jdbcTemplate.update("DELETE FROM AI_SESSION");
@@ -453,6 +456,35 @@ class JdbcSessionRepositoryTests {
 	// -------------------------------------------------------------------------
 	// Branch filtering
 	// -------------------------------------------------------------------------
+
+	@Test
+	void findEventsWithBranchFilterDelegatesToDialect() {
+		// Verify that the branch filter SQL comes from the dialect, not hardcoded.
+		// A custom dialect that wraps H2's fragment with a recognizable comment is used
+		// to confirm the call is made.
+		JdbcSessionRepository repoWithCustomDialect = JdbcSessionRepository.builder()
+			.dataSource(this.dataSource)
+			.dialect(new H2JdbcSessionRepositoryDialect() {
+				@Override
+				public String getBranchFilterFragment() {
+					return super.getBranchFilterFragment(); // delegates to default || impl
+				}
+			})
+			.build();
+
+		Session session = buildSession("user-dialect-wiring");
+		repoWithCustomDialect.save(session);
+		repoWithCustomDialect.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("root")).branch(null).build());
+		repoWithCustomDialect.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("child"))
+			.branch("a.b")
+			.build());
+
+		List<SessionEvent> forChild = repoWithCustomDialect.findEvents(session.id(), EventFilter.forBranch("a.b"));
+		assertThat(forChild).hasSize(2); // root + exact match
+	}
 
 	@Test
 	void findEventsWithBranchFilterIsolatesPeerAgents() {


### PR DESCRIPTION
In MySQL/MariaDB || is logical OR, not string concatenation, so the multi-agent branch visibility query silently returned wrong results. 

Add getBranchFilterFragment() to the dialect interface (default: ||) and override it in MysqlJdbcSessionRepositoryDialect to use CONCAT().