### PR TITLE
Add SessionService.deleteExpiredSessions() for explicit expiry cleanup

### DIFF
--- a/docs/session-management/concepts.md
+++ b/docs/session-management/concepts.md
@@ -218,11 +218,30 @@ List<Message> history = service.getMessages(session.id());
 // 4. Retrieve as SessionEvent list (for filtering, inspection, compaction)
 List<SessionEvent> events = service.getEvents(session.id());
 
-// 5. Delete
+// 5. Delete a single session
 service.delete(session.id());
+
+// 6. Delete all expired sessions (call from a scheduler)
+int removed = service.deleteExpiredSessions(Instant.now());
 ```
 
 Deleted sessions are removed from the repository entirely — there is no tombstone state.
+
+### Expiry cleanup
+
+Sessions are not automatically swept — `deleteExpiredSessions(Instant)` must be called
+explicitly. Wire it to a scheduler in your application:
+
+```java
+@Scheduled(fixedRate = 3_600_000) // every hour
+void sweepExpiredSessions() {
+    int removed = sessionService.deleteExpiredSessions(Instant.now());
+    log.info("Swept {} expired sessions", removed);
+}
+```
+
+`deleteExpiredSessions` finds all sessions whose `expiresAt` is before the supplied
+instant and deletes them one by one. It returns the count of sessions removed.
 
 ---
 

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/DefaultSessionService.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/DefaultSessionService.java
@@ -83,6 +83,14 @@ public class DefaultSessionService implements SessionService {
 	}
 
 	@Override
+	public int deleteExpiredSessions(Instant before) {
+		Assert.notNull(before, "before must not be null");
+		List<String> expired = this.sessionRepository.findExpiredSessionIds(before);
+		expired.forEach(this.sessionRepository::delete);
+		return expired.size();
+	}
+
+	@Override
 	public void appendEvent(SessionEvent event) {
 		Assert.notNull(event, "event must not be null");
 		this.sessionRepository.appendEvent(event);

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/SessionService.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/SessionService.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.session;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -42,6 +43,22 @@ public interface SessionService {
 	List<Session> findByUserId(String userId);
 
 	void delete(String sessionId);
+
+	/**
+	 * Deletes all sessions whose {@code expiresAt} is before {@code before}. Delegates
+	 * to {@link SessionRepository#findExpiredSessionIds(Instant)} then deletes each one.
+	 * Returns the number of sessions deleted.
+	 * <p>
+	 * This method does not schedule itself — call it from a {@code @Scheduled} method,
+	 * a Quartz job, or any other scheduler:
+	 * <pre>{@code
+	 * @Scheduled(fixedRate = 3_600_000) // every hour
+	 * void sweepExpiredSessions() {
+	 *     sessionService.deleteExpiredSessions(Instant.now());
+	 * }
+	 * }</pre>
+	 */
+	int deleteExpiredSessions(Instant before);
 
 	// Events
 

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/DefaultSessionServiceTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/DefaultSessionServiceTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.session;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -230,6 +231,43 @@ class DefaultSessionServiceTests {
 		assertThat(messages).hasSize(2);
 		assertThat(messages.get(0).getText()).isEqualTo("msg-4");
 		assertThat(messages.get(1).getText()).isEqualTo("msg-5");
+	}
+
+	// --- deleteExpiredSessions ---
+
+	@Test
+	void deleteExpiredSessionsRemovesOnlyExpiredSessions() {
+		Session active = this.service.create(CreateSessionRequest.builder()
+			.userId("u1")
+			.timeToLive(java.time.Duration.ofHours(1))
+			.build());
+		Session expired = this.service.create(CreateSessionRequest.builder()
+			.userId("u2")
+			.timeToLive(java.time.Duration.ofSeconds(-1)) // already in the past
+			.build());
+
+		int deleted = this.service.deleteExpiredSessions(Instant.now());
+
+		assertThat(deleted).isEqualTo(1);
+		assertThat(this.service.findById(active.id())).isNotNull();
+		assertThat(this.service.findById(expired.id())).isNull();
+	}
+
+	@Test
+	void deleteExpiredSessionsReturnsZeroWhenNoneExpired() {
+		this.service.create(CreateSessionRequest.builder()
+			.userId("u1")
+			.timeToLive(java.time.Duration.ofHours(1))
+			.build());
+
+		int deleted = this.service.deleteExpiredSessions(Instant.now());
+
+		assertThat(deleted).isZero();
+	}
+
+	@Test
+	void deleteExpiredSessionsReturnsZeroWhenNoSessions() {
+		assertThat(this.service.deleteExpiredSessions(Instant.now())).isZero();
 	}
 
 }


### PR DESCRIPTION
findExpiredSessionIds() existed on the repository but was never called, letting sessions accumulate indefinitely. 
Add deleteExpiredSessions(Instant) to SessionService so callers can drive cleanup from any scheduler (@Scheduled, Quartz, etc.) without the library imposing a dependency.