### PR TITLE
Extend branch-awareness to all compaction strategies

### DIFF
--- a/docs/session-management/compaction.md
+++ b/docs/session-management/compaction.md
@@ -122,7 +122,7 @@ SlidingWindowCompactionStrategy.builder().maxEvents(20).tokenCountEstimator(myEs
 
 1. Separate synthetic events (always preserved, placed first in output).
 2. Keep the last `maxEvents` real events.
-3. Snap the cut point forward to the nearest `USER` message (turn-boundary safety).
+3. Snap the cut point forward to the nearest root-level `USER` message (turn-boundary safety).
 4. Return: `[synthetics] + [kept real events]`.
 
 ### TurnWindowCompactionStrategy
@@ -167,7 +167,7 @@ TokenCountCompactionStrategy.builder().maxTokens(4000).tokenCountEstimator(myEst
    first event that would exceed the remaining budget. This produces a **contiguous
    suffix** — skipping individual oversize events would create non-contiguous gaps that
    break conversation coherence.
-3. Drop any leading kept events that are not `USER` messages (turn-boundary safety).
+3. Drop any leading kept events that are not root-level `USER` messages (turn-boundary safety).
 4. Return: `[synthetics] + [kept events]`.
 
 ### RecursiveSummarizationCompactionStrategy
@@ -246,16 +246,40 @@ predecessors without starting from scratch.
 ## Turn-boundary Safety
 
 All four strategies share a common safety rule enforced by
-`CompactionUtils.snapToTurnStart`: the kept window always starts at a `USER` message.
+`CompactionUtils.snapToTurnStart`: the kept window always starts at a **root-level**
+`USER` message — one whose `branch` is `null`.
 
-If a raw cut point lands on an `ASSISTANT` or `TOOL` event in the middle of a turn, it
-is advanced forward to the next `USER` message. This prevents keeping a tool result or
-assistant reply without the user message that originated its turn.
+If a raw cut point lands in the middle of a turn, it is advanced forward to the next
+qualifying event. This prevents keeping a tool result or assistant reply without the user
+message that originated its turn.
 
 ```
 Before snap:  [u1, a1, u2, a2, | a3, u3, a3]   ← cut lands on a3 (middle of turn 2)
 After snap:   [u1, a1, u2, a2, a3, | u3, a3]   ← cut moved to u3 (turn start)
 ```
+
+### Branch-awareness in multi-agent sessions
+
+In multi-agent sessions, `UserMessage` events appear on named branches (e.g.
+`branch="orch.researcher"`) as well as at the root level. A branched `UserMessage` is the
+prompt sent *to* a sub-agent — it is **turn-internal**, not a turn boundary.
+
+A single root turn can contain an entire sub-agent exchange:
+
+```
+[branch=null]  USER:      "What's the weather in Paris?"      ← real turn start
+[branch=null]  ASSISTANT: [tool call: delegate_to_agent]
+[branch="sub"] USER:      "Fetch weather for Paris"           ← internal sub-agent prompt
+[branch="sub"] ASSISTANT: [tool call: get_weather]
+[branch="sub"] TOOL:      {temp: "22C"}
+[branch="sub"] ASSISTANT: "It's 22°C in Paris"
+[branch=null]  ASSISTANT: "The weather in Paris is 22°C"
+```
+
+`snapToTurnStart` skips all branched events regardless of message type, and only stops
+when it finds a `USER` event with `branch == null` (i.e. `SessionEvent.isRootEvent()`).
+This prevents the cut from landing on a sub-agent prompt and leaving the root turn's user
+message in the archived window.
 
 ---
 

--- a/docs/session-management/multi-agent.md
+++ b/docs/session-management/multi-agent.md
@@ -116,3 +116,16 @@ Synthetic summary events produced by `RecursiveSummarizationCompactionStrategy` 
 have `branch = null`. This ensures compaction summaries remain visible to every agent in
 the session after context has been pruned, regardless of which branch was active when
 compaction ran.
+
+---
+
+## Compaction and branches
+
+Compaction strategies are branch-aware. When computing the cut point, `snapToTurnStart`
+only considers root-level (`branch == null`) `USER` events as valid turn boundaries.
+Branched `UserMessage` events represent prompts sent *to* a sub-agent and are
+turn-internal — snapping to one would split the root turn that contains the sub-agent
+exchange.
+
+See [Turn-boundary Safety](compaction.md#turn-boundary-safety) in the compaction reference
+for the full explanation and event-log diagram.

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/SessionEvent.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/SessionEvent.java
@@ -129,6 +129,16 @@ public final class SessionEvent {
 	}
 
 	/**
+	 * Returns {@code true} if this event belongs to the root conversation thread, i.e.
+	 * was not produced inside any delegated sub-agent branch. Root events have a
+	 * {@code null} branch.
+	 * @return {@code true} if this event is a root-level event, {@code false} otherwise
+	 */
+	public boolean isRootEvent() {
+		return (this.branch == null);
+	}
+
+	/**
 	 * Convenience accessor — delegates to the wrapped message. No need to unwrap for
 	 * common type-switch operations.
 	 */

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/CompactionRequest.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/CompactionRequest.java
@@ -52,7 +52,7 @@ public record CompactionRequest(Session session, List<SessionEvent> events, int 
 		int turnCount = (int) events.stream()
 			.filter(e -> !e.isSynthetic())
 			.filter(e -> e.getMessageType() == MessageType.USER)
-			.filter(e -> e.getBranch() == null)
+			.filter(SessionEvent::isRootEvent)
 			.count();
 		return new CompactionRequest(session, events, eventCount, turnCount);
 	}

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/CompactionUtils.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/CompactionUtils.java
@@ -43,8 +43,10 @@ final class CompactionUtils {
 	 * Handles all Spring AI message types:
 	 * <ul>
 	 * <li>Plain user / assistant / system messages → {@code "Role: text"}</li>
-	 * <li>{@link AssistantMessage} with tool calls → {@code "Assistant [tool calls: name(args), ...]"}</li>
-	 * <li>{@link ToolResponseMessage} → {@code "Tool [responses: name -> data, ...]"}</li>
+	 * <li>{@link AssistantMessage} with tool calls →
+	 * {@code "Assistant [tool calls: name(args), ...]"}</li>
+	 * <li>{@link ToolResponseMessage} →
+	 * {@code "Tool [responses: name -> data, ...]"}</li>
 	 * </ul>
 	 * @param event the session event to format
 	 * @return a non-null, non-empty string representing the event
@@ -80,7 +82,7 @@ final class CompactionUtils {
 	}
 
 	/**
-	 * Advances {@code rawCutIndex} forward until it points to a null-branch 
+	 * Advances {@code rawCutIndex} forward until it points to a root-level (null-branch)
 	 * {@link MessageType#USER} event, or to {@code real.size()} if no such event exists.
 	 *
 	 * <p>
@@ -91,13 +93,13 @@ final class CompactionUtils {
 	 * kept window always begins at a complete turn, preserving conversation semantics.
 	 * @param real the list of non-synthetic session events
 	 * @param rawCutIndex the initial cut point; must be in {@code [0, real.size()]}
-	 * @return the adjusted index pointing to the first null-branch USER event at or after
+	 * @return the adjusted index pointing to the first root-level USER event at or after
 	 * {@code rawCutIndex}, or {@code real.size()} if none exists
 	 */
 	static int snapToTurnStart(List<SessionEvent> real, int rawCutIndex) {
 		int idx = rawCutIndex;
 		while (idx < real.size()
-				&& !(real.get(idx).getBranch() == null && real.get(idx).getMessageType() == MessageType.USER)) {
+				&& !(real.get(idx).isRootEvent() && real.get(idx).getMessageType() == MessageType.USER)) {
 			idx++;
 		}
 		return idx;

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/RecursiveSummarizationCompactionStrategy.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/RecursiveSummarizationCompactionStrategy.java
@@ -60,7 +60,7 @@ import org.springframework.util.Assert;
  * summary. This means each summary <em>builds on</em> its predecessors rather than
  * starting from scratch, creating a rolling window of compressed context.
  *
- * <h3>No-op condition</h3> If the total number of real events does not exceed
+ * <h3>No-op condition</h3> If the number of root (non-branch) real events does not exceed
  * {@code maxEventsToKeep} no LLM call is made and the events are returned unchanged.
  *
  * @author Christian Tzolov
@@ -150,16 +150,33 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 		List<SessionEvent> syntheticEvents = events.stream().filter(SessionEvent::isSynthetic).toList();
 		List<SessionEvent> realEvents = events.stream().filter(e -> !e.isSynthetic()).toList();
 
-		if (realEvents.size() <= this.maxEventsToKeep) {
+		// Count only root (non-branch) real events. Branch events from sub-agent sessions
+		// are bundled with their enclosing root turns and do not consume slots from the
+		// maxEventsToKeep budget.
+		long rootEventCount = realEvents.stream().filter(SessionEvent::isRootEvent).count();
+
+		if (rootEventCount <= this.maxEventsToKeep) {
 			// Nothing to compact — return as-is
 			return new CompactionResult(events, List.of(), 0);
 		}
 
-		// Raw cut point based on event count alone
-		int rawCutIndex = realEvents.size() - this.maxEventsToKeep;
+		// Find the index in realEvents just after the last root event to archive.
+		long rootEventsToArchive = rootEventCount - this.maxEventsToKeep;
+		int rawCutIndex = 0;
+		long rootSeen = 0;
+		for (int i = 0; i < realEvents.size(); i++) {
+			if (realEvents.get(i).isRootEvent()) {
+				rootSeen++;
+				if (rootSeen == rootEventsToArchive) {
+					rawCutIndex = i + 1;
+					break;
+				}
+			}
+		}
 
-		// Snap forward to the nearest turn start (USER message) so the active window
-		// always begins at a turn boundary and is never a partial turn.
+		// Snap forward to the nearest root-level turn start (USER message) so the active
+		// window always begins at a turn boundary and is never a partial turn.
+		// Sub-agent USER messages (branch != null) are skipped — they are turn-internal.
 		int cutIndex = CompactionUtils.snapToTurnStart(realEvents, rawCutIndex);
 
 		// Split real events: archive the older ones, keep the newest window

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategy.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategy.java
@@ -32,12 +32,13 @@ import org.springframework.util.Assert;
  * <ol>
  * <li>Separate synthetic summary events — they are always preserved and placed first in
  * the result.</li>
- * <li>Compute a raw cut index so that at most {@code maxEvents - syntheticCount} real
- * events are kept.</li>
- * <li>Snap the raw cut index forward to the nearest
+ * <li>Compute a raw cut index based on root (non-branch) real events only. Branch events
+ * produced by sub-agents do not consume slots from the {@code maxEvents} budget — they
+ * are always included with their enclosing root turn.</li>
+ * <li>Snap the raw cut index forward to the nearest root-level
  * {@link org.springframework.ai.chat.messages.MessageType#USER} event so the kept window
- * always starts at a turn boundary. This prevents keeping an assistant reply or tool
- * result without the user message that originated its turn.</li>
+ * always starts at a turn boundary. Sub-agent USER messages are skipped because they are
+ * turn-internal, not turn starts.</li>
  * <li>Return: {@code [synthetic summaries] + [kept real events]}.</li>
  * </ol>
  *
@@ -79,15 +80,36 @@ public final class SlidingWindowCompactionStrategy implements CompactionStrategy
 
 		// maxEvents controls the real-events window only; synthetic summary events are
 		// always preserved on top and do not consume slots from the real-event budget.
+		// Branch events produced inside sub-agent sessions also do not consume slots —
+		// they are always included with their enclosing root turn.
 		int slotsForReal = this.maxEvents;
 
-		// No-op if real events fit within the available slots
-		if (real.size() <= slotsForReal) {
+		// Count only root (non-branch) real events to determine whether compaction is needed
+		// and where to place the raw cut. Branch events tagged with a non-null branch are
+		// turn-internal and are always carried along with their enclosing root turn.
+		long rootEventCount = real.stream().filter(SessionEvent::isRootEvent).count();
+
+		// No-op if root events fit within the available slots
+		if (rootEventCount <= slotsForReal) {
 			return new CompactionResult(events, List.of(), 0);
 		}
 
-		// Raw cut point: index where the kept window would start based on count alone
-		int rawCutIndex = real.size() - slotsForReal;
+		// Find the index in 'real' just after the last root event to archive.
+		// Walk forward counting root events; place the raw cut right after the
+		// (rootEventCount - slotsForReal)-th root event so snapToTurnStart can advance
+		// it to the next root-level USER event.
+		long rootEventsToArchive = rootEventCount - slotsForReal;
+		int rawCutIndex = 0;
+		long rootSeen = 0;
+		for (int i = 0; i < real.size(); i++) {
+			if (real.get(i).isRootEvent()) {
+				rootSeen++;
+				if (rootSeen == rootEventsToArchive) {
+					rawCutIndex = i + 1;
+					break;
+				}
+			}
+		}
 
 		// Snap forward to the nearest turn start (USER message) so we never keep a
 		// partial turn — e.g. an assistant reply without its originating user message.

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategy.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategy.java
@@ -19,7 +19,6 @@ package org.springframework.ai.session.compaction;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.session.SessionEvent;
 import org.springframework.ai.tokenizer.JTokkitTokenCountEstimator;
 import org.springframework.ai.tokenizer.TokenCountEstimator;
@@ -39,9 +38,9 @@ import org.springframework.util.Assert;
  * exhausted. Stops at the first event that would exceed the remaining budget, producing a
  * contiguous kept window (a suffix of the real-event list). Skipping oversize events and
  * continuing would produce non-contiguous gaps that break conversation coherence.</li>
- * <li>Drop any leading kept events that are not {@link MessageType#USER} messages. This
- * guarantees the kept window always starts at a turn boundary, so an assistant reply or
- * tool result is never kept without the user message that originated its turn.</li>
+ * <li>Snap the cut point to the next root-level ({@code branch == null}) user message.
+ * This guarantees the kept window always starts at a turn boundary — sub-agent
+ * {@code USER} messages are skipped because they are turn-internal, not turn starts.</li>
  * <li>Return: {@code [synthetic events] + [kept events]}.</li>
  * </ol>
  *
@@ -90,29 +89,27 @@ public final class TokenCountCompactionStrategy implements CompactionStrategy {
 		// Stop at the first event that would exceed the remaining budget so the kept
 		// window is always a contiguous suffix — keeping older events after skipping a
 		// large middle event would produce gaps that break conversation coherence.
-		int cutIndex = real.size();
+		int rawCutIndex = real.size();
 		int usedTokens = 0;
 		for (int i = real.size() - 1; i >= 0; i--) {
 			int tokens = this.tokenCountEstimator.estimate(CompactionUtils.formatEvent(real.get(i)));
 			if (usedTokens + tokens <= remainingBudget) {
 				usedTokens += tokens;
-				cutIndex = i;
+				rawCutIndex = i;
 			}
 			else {
 				break;
 			}
 		}
 
+		// Snap the raw cut forward to the nearest root-level USER event so the kept
+		// window always starts at a turn boundary. Sub-agent USER messages (branch != null)
+		// are skipped — they are turn-internal, not turn starts.
+		int cutIndex = CompactionUtils.snapToTurnStart(real, rawCutIndex);
+
 		// Build kept and archived lists in chronological order
 		List<SessionEvent> kept = new ArrayList<>(real.subList(cutIndex, real.size()));
 		List<SessionEvent> archived = new ArrayList<>(real.subList(0, cutIndex));
-
-		// Ensure the kept window starts at a turn boundary (USER message).
-		// Drop any leading kept events that are not USER messages — keeping an assistant
-		// reply without its originating user message breaks conversation semantics.
-		while (!kept.isEmpty() && kept.get(0).getMessageType() != MessageType.USER) {
-			archived.add(kept.remove(0));
-		}
 
 		if (archived.isEmpty()) {
 			return new CompactionResult(events, List.of(), 0);

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategy.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategy.java
@@ -86,13 +86,15 @@ public final class TurnWindowCompactionStrategy implements CompactionStrategy {
 		// (e.g., pre-seeded tool context). These are kept verbatim.
 		List<SessionEvent> preamble = new ArrayList<>();
 		int firstUserIdx = 0;
-		while (firstUserIdx < real.size() && real.get(firstUserIdx).getMessageType() != MessageType.USER) {
+		while (firstUserIdx < real.size()
+				&& !(real.get(firstUserIdx).isRootEvent()
+						&& real.get(firstUserIdx).getMessageType() == MessageType.USER)) {
 			preamble.add(real.get(firstUserIdx));
 			firstUserIdx++;
 		}
 		List<SessionEvent> afterPreamble = real.subList(firstUserIdx, real.size());
 
-		// 3. Group into turns — each turn starts at a user message
+		// 3. Group into turns — each turn starts at a root-level user message
 		List<List<SessionEvent>> turns = groupIntoTurns(afterPreamble);
 
 		// 4. No-op if within budget
@@ -121,16 +123,17 @@ public final class TurnWindowCompactionStrategy implements CompactionStrategy {
 	}
 
 	/**
-	 * Groups a flat list of events into turns. Each turn starts with a
-	 * {@link MessageType#USER} event. Assumes {@code events} begins with a user message
-	 * (preamble has already been stripped).
+	 * Groups a flat list of events into turns. Each turn starts with a root-level
+	 * ({@code branch == null}) {@link MessageType#USER} event. Sub-agent branch events are
+	 * grouped with the enclosing root turn. Assumes {@code events} begins with a root user
+	 * message (preamble has already been stripped).
 	 */
 	private static List<List<SessionEvent>> groupIntoTurns(List<SessionEvent> events) {
 		List<List<SessionEvent>> turns = new ArrayList<>();
 		List<SessionEvent> currentTurn = null;
 
 		for (SessionEvent event : events) {
-			if (event.getMessageType() == MessageType.USER) {
+			if (event.isRootEvent() && event.getMessageType() == MessageType.USER) {
 				if (currentTurn != null) {
 					turns.add(currentTurn);
 				}

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategyTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategyTests.java
@@ -222,6 +222,71 @@ class SlidingWindowCompactionStrategyTests {
 		assertThat(result.tokensEstimatedSaved()).isGreaterThan(0);
 	}
 
+	// --- branch-awareness ---
+
+	@Test
+	void branchEventsDoNotConsumeMaxEventsSlots() {
+		// real=[u1, a1, sub-q(branch), sub-a(branch), u2, a2] → 4 root events, 2 branch
+		// maxEvents=2 → archive 2 root events (u1, a1); kept window starts at u2.
+		// Branch events between the archived and kept root turns are also archived because
+		// they fall before the snap cut point.
+		SlidingWindowCompactionStrategy strategy = SlidingWindowCompactionStrategy.builder().maxEvents(2).build();
+
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u1")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a1")).build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new UserMessage("sub-q"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new AssistantMessage("sub-a"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u2")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a2")).build());
+
+		CompactionResult result = strategy.compact(contextFor(events));
+
+		assertThat(result.compactedEvents()).hasSize(2);
+		assertThat(result.compactedEvents().get(0).getMessage().getText()).isEqualTo("u2");
+		assertThat(result.compactedEvents().get(1).getMessage().getText()).isEqualTo("a2");
+		assertThat(result.archivedEvents()).hasSize(4); // u1, a1, sub-q, sub-a
+	}
+
+	@Test
+	void noCompactionWhenRootEventsWithinBudgetDespiteExcessTotalEvents() {
+		// real=[u1, a1, sub-q(branch), sub-a(branch), u2, a2] — 6 total, 4 root events
+		// maxEvents=4 → 4 root events <= 4 slots → no-op (branch events come for free)
+		// Old behaviour (count all real events): 6 > 4 → would compact and start window
+		// at branch USER u2-sub, which is semantically wrong.
+		SlidingWindowCompactionStrategy strategy = SlidingWindowCompactionStrategy.builder().maxEvents(4).build();
+
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u1")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a1")).build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new UserMessage("sub-q"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new AssistantMessage("sub-a"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u2")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a2")).build());
+
+		CompactionResult result = strategy.compact(contextFor(events));
+
+		// All 6 events returned unchanged — no compaction needed
+		assertThat(result.archivedEvents()).isEmpty();
+		assertThat(result.compactedEvents()).hasSize(6);
+	}
+
 	private List<SessionEvent> buildRealEvents(int count) {
 		List<SessionEvent> events = new ArrayList<>();
 		for (int i = 1; i <= count; i++) {

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategyTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategyTests.java
@@ -250,6 +250,56 @@ class TokenCountCompactionStrategyTests {
 		assertThat(result.archivedEvents()).isEmpty();
 	}
 
+	// --- branch-awareness ---
+
+	@Test
+	void snapSkipsBranchUserEventOnTurnBoundary() {
+		// Events (CHAR_ESTIMATOR costs based on formatEvent output):
+		//   u1-root "User: u1" = 8, a1-root "Assistant: a1" = 13
+		//   u2-sub  "User: u2" = 8, a2-sub  "Assistant: a2" = 13  (branch="sub")
+		//   u3-root "User: u3" = 8, a3-root "Assistant: a3" = 13
+		//
+		// Backwards scan with budget=40:
+		//   a3-root(13) fits, u3-root(8) → 21 fits, a2-sub(13) → 34 fits,
+		//   u2-sub(8)   → 42 > 40, stop  →  rawCutIndex = 3 (a2-sub)
+		//
+		// snapToTurnStart(real, 3):
+		//   idx=3: a2-sub (branch → not root → skip)
+		//   idx=4: u3-root (root USER → stop)
+		// → cutIndex=4, kept=[u3-root, a3-root]
+		//
+		// Without branch-awareness the old snap would have stopped at u2-sub (branch USER),
+		// leaving the kept window starting on a sub-agent message.
+		TokenCountCompactionStrategy strategy = TokenCountCompactionStrategy.builder()
+			.maxTokens(40)
+			.tokenCountEstimator(CHAR_ESTIMATOR)
+			.build();
+
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u1")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a1")).build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new UserMessage("u2"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new AssistantMessage("a2"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u3")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a3")).build());
+
+		CompactionResult result = strategy.compact(requestWith(events));
+
+		// Kept window must start at root USER u3, not branch USER u2
+		assertThat(result.compactedEvents()).hasSize(2);
+		assertThat(result.compactedEvents().get(0).getMessage().getText()).isEqualTo("u3");
+		assertThat(result.compactedEvents().get(1).getMessage().getText()).isEqualTo("a3");
+		assertThat(result.archivedEvents()).hasSize(4); // u1, a1, u2-sub, a2-sub
+	}
+
 	// --- tool call / tool response token counting ---
 
 	@Test

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategyTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategyTests.java
@@ -276,6 +276,76 @@ class TurnWindowCompactionStrategyTests {
 		assertThat(result.tokensEstimatedSaved()).isGreaterThan(0);
 	}
 
+	// --- branch-awareness ---
+
+	@Test
+	void branchUserEventsDoNotInflateTurnCount() {
+		// Root turn 1: [u1, a1, sub-q (branch), sub-a (branch)] — sub-agent exchange inside turn 1
+		// Root turn 2: [u2, a2]
+		// Root turn 3: [u3, a3]
+		// Without branch-awareness the branch USER event would be counted as a 4th turn start,
+		// causing premature archiving.
+		TurnWindowCompactionStrategy strategy = TurnWindowCompactionStrategy.builder().maxTurns(2).build();
+
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u1")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a1")).build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new UserMessage("sub-q"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new AssistantMessage("sub-a"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u2")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a2")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u3")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a3")).build());
+
+		CompactionResult result = strategy.compact(requestWith(events));
+
+		// Exactly 3 root turns; archive root turn 1 (4 events incl. branch), keep turns 2 and 3
+		assertThat(result.archivedEvents()).hasSize(4);
+		assertThat(result.compactedEvents()).hasSize(4);
+		assertThat(result.compactedEvents().get(0).getMessage().getText()).isEqualTo("u2");
+		assertThat(result.compactedEvents().get(2).getMessage().getText()).isEqualTo("u3");
+	}
+
+	@Test
+	void preambleScanSkipsBranchUserEvents() {
+		// Branch events appear before the first root USER — they belong to the preamble.
+		// maxTurns=1 → archive root turn 1, keep root turn 2.
+		TurnWindowCompactionStrategy strategy = TurnWindowCompactionStrategy.builder().maxTurns(1).build();
+
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new UserMessage("sub-q"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder()
+			.sessionId(SESSION_ID)
+			.message(new AssistantMessage("sub-a"))
+			.branch("sub")
+			.build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u1")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a1")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("u2")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("a2")).build());
+
+		CompactionResult result = strategy.compact(requestWith(events));
+
+		// Preamble [sub-q, sub-a] preserved; root turn 1 [u1, a1] archived; root turn 2 [u2, a2] kept
+		assertThat(result.archivedEvents()).hasSize(2);
+		assertThat(result.archivedEvents().get(0).getMessage().getText()).isEqualTo("u1");
+		assertThat(result.compactedEvents()).hasSize(4); // [sub-q, sub-a, u2, a2]
+		assertThat(result.compactedEvents().get(0).getMessage().getText()).isEqualTo("sub-q");
+		assertThat(result.compactedEvents().get(2).getMessage().getText()).isEqualTo("u2");
+	}
+
 	// --- helpers ---
 
 	private List<SessionEvent> turn(String userText, String assistantText) {


### PR DESCRIPTION
- Add SessionEvent.isRootEvent() as a named predicate for the branch == null invariant. Use it in CompactionUtils.snapToTurnStart() so the cut point skips sub-agent UserMessage events (which are turn-internal) and only lands on root-level turn boundaries.
- Apply isRootEvent() checks consistently across all four strategies:
- Update the reference docs.