### PR TITLE
Align SESSION_ID_CONTEXT_KEY with ChatMemory.CONVERSATION_ID and set default order to 1000

### DIFF
--- a/docs/session-management/chat-client.md
+++ b/docs/session-management/chat-client.md
@@ -58,6 +58,12 @@ ChatClient client = ChatClient.builder(chatModel)
     Setting only one of `compactionTrigger` or `compactionStrategy` throws
     `IllegalStateException`. Set both or neither.
 
+!!! note "Default advisor order"
+    The default order is `1000`, which places `SessionMemoryAdvisor` after the
+    `ToolAdvisor` (order `300`). This ensures tool-call events are captured in
+    the session history before the tool advisor's `before()` callback processes them.
+    Override with `.order(n)` if your pipeline requires a different position.
+
 ---
 
 ## Passing a session ID per request
@@ -102,7 +108,7 @@ If no session exists for the given ID, the advisor creates one automatically usi
 
 | Key constant | String value | Purpose |
 |---|---|---|
-| `SESSION_ID_CONTEXT_KEY` | `"chat_memory_session_id"` | Routes the request to a session |
+| `SESSION_ID_CONTEXT_KEY` | `"chat_memory_conversation_id"` (= `ChatMemory.CONVERSATION_ID`) | Routes the request to a session |
 | `USER_ID_CONTEXT_KEY` | `"chat_memory_user_id"` | Used when auto-creating a session; also enforces ownership on existing sessions when set |
 | `EVENT_FILTER_CONTEXT_KEY` | `"chat_memory_event_filter_id"` | Per-request `EventFilter` merged with the advisor-level filter |
 

--- a/docs/session-management/recall-storage.md
+++ b/docs/session-management/recall-storage.md
@@ -20,13 +20,13 @@ SessionEventTools tools = SessionEventTools.builder(sessionService)
 
 ChatClient client = ChatClient.builder(chatModel)
     .defaultTools(tools)
-    .defaultAdvisors(advisor)   // SessionMemoryAdvisor sets chat_memory_session_id
+    .defaultAdvisors(advisor)   // SessionMemoryAdvisor sets chat_memory_conversation_id
     .build();
 ```
 
 !!! tip
     Register `SessionMemoryAdvisor` alongside `SessionEventTools`. The advisor writes the
-    `chat_memory_session_id` context key that the tool uses to resolve the active session.
+    `chat_memory_conversation_id` context key (`ChatMemory.CONVERSATION_ID`) that the tool uses to resolve the active session.
     Without the advisor, the tool falls back to the literal session ID `"default"`.
 
 ---
@@ -56,8 +56,8 @@ When nothing matches: `"No results found."` is returned.
 
 ## How it works
 
-1. Resolves the session ID from `ToolContext` using the `chat_memory_session_id` key
-   (the same key written by `SessionMemoryAdvisor`). If the key is absent or blank, a
+1. Resolves the session ID from `ToolContext` using the `chat_memory_conversation_id` key
+   (`ChatMemory.CONVERSATION_ID`, the same key written by `SessionMemoryAdvisor`). If the key is absent or blank, a
    `WARN`-level log is emitted and the tool falls back to the literal session ID
    `"default"`.
 2. Calls `SessionService.getEvents(sessionId, EventFilter.keywordSearch(query, page, pageSize))`.

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
@@ -28,11 +28,11 @@ import reactor.core.scheduler.Scheduler;
 import org.springframework.ai.chat.client.ChatClientMessageAggregator;
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
-import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.client.advisor.api.MemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.session.CreateSessionRequest;
@@ -76,10 +76,12 @@ import org.springframework.util.Assert;
 public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 
 	/**
-	 * Context key used to pass the session ID into the advisor per-request. Set via:
+	 * Context key used to pass the session ID into the advisor per-request. Equals
+	 * {@link org.springframework.ai.chat.memory.ChatMemory#CONVERSATION_ID} so that this
+	 * advisor uses the same context key as the rest of Spring AI's memory API. Set via:
 	 * {@code .advisors(a -> a.param(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, "my-session-id"))}
 	 */
-	public static final String SESSION_ID_CONTEXT_KEY = "chat_memory_session_id";
+	public static final String SESSION_ID_CONTEXT_KEY = ChatMemory.CONVERSATION_ID;
 
 	/**
 	 * Context key used to pass the user ID into the advisor per-request. Set via:
@@ -103,8 +105,8 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 
 	@Nullable private final CompactionStrategy compactionStrategy;
 
-	private SessionMemoryAdvisor(SessionService sessionService, String defaultUserId,
-			int order, Scheduler scheduler, EventFilter eventFilter, @Nullable CompactionTrigger compactionTrigger,
+	private SessionMemoryAdvisor(SessionService sessionService, String defaultUserId, int order, Scheduler scheduler,
+			EventFilter eventFilter, @Nullable CompactionTrigger compactionTrigger,
 			@Nullable CompactionStrategy compactionStrategy) {
 		this.sessionService = sessionService;
 		this.defaultUserId = defaultUserId;
@@ -146,8 +148,8 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 			Object userIdValue = request.context().get(USER_ID_CONTEXT_KEY);
 			if (userIdValue instanceof String requestUserId && !requestUserId.isBlank()
 					&& !requestUserId.equals(session.userId())) {
-				throw new IllegalStateException("Session '" + sessionId + "' does not belong to user '"
-						+ requestUserId + "'. Access denied.");
+				throw new IllegalStateException(
+						"Session '" + sessionId + "' does not belong to user '" + requestUserId + "'. Access denied.");
 			}
 		}
 
@@ -231,9 +233,9 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 		if (value instanceof String s && !s.isBlank()) {
 			return s;
 		}
-		throw new IllegalStateException("No session ID found in advisor context. "
-				+ "Set SESSION_ID_CONTEXT_KEY on every request: "
-				+ ".advisors(a -> a.param(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, sessionId))");
+		throw new IllegalStateException(
+				"No session ID found in advisor context. " + "Set SESSION_ID_CONTEXT_KEY on every request: "
+						+ ".advisors(a -> a.param(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, sessionId))");
 	}
 
 	private String getUserId(Map<String, @Nullable Object> context) {
@@ -251,7 +253,10 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 
 		private String defaultUserId = "default-user";
 
-		private int order = Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER;
+		// Default order 1000 ensures this advisor runs after the ToolAdvisor (order 300),
+		// so tool-call events are captured in the session history before the tool advisor's
+		// before() callback can remove them from the prompt.
+		private int order = 1000;
 
 		private Scheduler scheduler = BaseAdvisor.DEFAULT_SCHEDULER;
 
@@ -313,8 +318,8 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 				throw new IllegalArgumentException(
 						"compactionTrigger and compactionStrategy must be set together — set both or neither");
 			}
-			return new SessionMemoryAdvisor(this.sessionService, this.defaultUserId, this.order,
-					this.scheduler, this.eventFilter, this.compactionTrigger, this.compactionStrategy);
+			return new SessionMemoryAdvisor(this.sessionService, this.defaultUserId, this.order, this.scheduler,
+					this.eventFilter, this.compactionTrigger, this.compactionStrategy);
 		}
 
 	}

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/tool/SessionEventTools.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/tool/SessionEventTools.java
@@ -40,9 +40,11 @@ import org.springframework.util.StringUtils;
  * context compaction has pruned older events from the active context window.
  *
  * <p>
- * The session to search is resolved from {@link ToolContext} using the
- * {@code chat_memory_session_id} key, which is the same key used by
- * {@code SessionMemoryAdvisor}. Register an instance of this class as a tool on the
+ * The session to search is resolved from {@link ToolContext} using
+ * {@link org.springframework.ai.session.advisor.SessionMemoryAdvisor#SESSION_ID_CONTEXT_KEY}
+ * (equals {@link org.springframework.ai.chat.memory.ChatMemory#CONVERSATION_ID}), which is
+ * the same key written into the context by {@code SessionMemoryAdvisor}. Register an
+ * instance of this class as a tool on the
  * {@code ChatClient} alongside the advisor:
  *
  * <pre>{@code
@@ -62,8 +64,11 @@ public class SessionEventTools {
 
 	private static final Logger logger = LoggerFactory.getLogger(SessionEventTools.class);
 
-	/** Context key used to resolve the session ID from {@link ToolContext}. */
-	public static final String SESSION_ID_CONTEXT_KEY = "chat_memory_session_id";
+	/**
+	 * Context key used to resolve the session ID from {@link ToolContext}. Must match
+	 * {@link org.springframework.ai.session.advisor.SessionMemoryAdvisor#SESSION_ID_CONTEXT_KEY}.
+	 */
+	public static final String SESSION_ID_CONTEXT_KEY = "chat_memory_conversation_id";
 
 	private final SessionService sessionService;
 


### PR DESCRIPTION
- Replace the custom chat_memory_session_id constant with ChatMemory.CONVERSATION_ID so session IDs are passed using the same key as the rest of Spring AI's memory API
- Set the default advisor order to 1000 (after ToolAdvisor at 300) so tool calls are captured in session history before the tool advisor's before() callback strips them
- Minor formatting cleanup in constructor and exception messages
- Update docs