### PR TITLE
fix: skip empty assistant messages to prevent Bedrock Converse ValidationException

### DIFF
--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
@@ -33,6 +33,7 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.client.advisor.api.MemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.session.CreateSessionRequest;
@@ -54,7 +55,8 @@ import org.springframework.util.Assert;
  * <ol>
  * <li>Retrieves the session's event history and prepends it to the prompt messages.</li>
  * <li>Appends the current user message to the session.</li>
- * <li>After the model responds, appends the assistant message to the session.</li>
+ * <li>After the model responds, appends the assistant message to the session;
+ *     empty assistant messages (blank text and no tool calls) are skipped.</li>
  * <li>Optionally triggers context compaction if the configured trigger fires.</li>
  * </ol>
  *
@@ -197,12 +199,16 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 	public ChatClientResponse after(ChatClientResponse response, AdvisorChain advisorChain) {
 		String sessionId = getSessionId(response.context());
 
-		// 1. Append the assistant message(s) produced by the model
+		// 1. Append the assistant message(s) produced by the model. Empty frames —
+		// blank text and no tool calls — are not stored. Some models (e.g. Bedrock
+		// Converse) emit such a frame to signal end_turn after a tool-call sequence;
+		// replaying it on the next request causes a validation error on those models.
 		if (response.chatResponse() != null) {
 			response.chatResponse()
 				.getResults()
 				.stream()
 				.map(g -> (Message) g.getOutput())
+				.filter(msg -> !isEmptyAssistantMessage(msg))
 				.forEach(msg -> this.sessionService.appendMessage(sessionId, msg));
 		}
 
@@ -242,6 +248,19 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 	private String getUserId(Map<String, @Nullable Object> context) {
 		Object value = context.get(USER_ID_CONTEXT_KEY);
 		return (value instanceof String s && !s.isBlank()) ? s : this.defaultUserId;
+	}
+
+	/**
+	 * Returns {@code true} for an {@link AssistantMessage} that carries neither text
+	 * nor tool calls. Such messages are implementation artifacts emitted by some models
+	 * (e.g. Bedrock Converse {@code end_turn} after a tool-call sequence) and carry no
+	 * conversational value. Storing and replaying them causes validation errors on those
+	 * same models.
+	 */
+	private static boolean isEmptyAssistantMessage(Message message) {
+		return message instanceof AssistantMessage am
+				&& (am.getText() == null || am.getText().isBlank())
+				&& !am.hasToolCalls();
 	}
 
 	public static Builder builder(SessionService sessionService) {

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -45,6 +47,7 @@ import org.springframework.ai.session.compaction.CompactionStrategy;
 import org.springframework.ai.session.compaction.CompactionTrigger;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 /**
  * A {@link BaseAdvisor} that manages conversation history using the
@@ -56,7 +59,7 @@ import org.springframework.util.Assert;
  * <li>Retrieves the session's event history and prepends it to the prompt messages.</li>
  * <li>Appends the current user message to the session.</li>
  * <li>After the model responds, appends the assistant message to the session;
- *     empty assistant messages (blank text and no tool calls) are skipped.</li>
+ *     empty assistant messages (blank text, no tool calls, and no media) are skipped.</li>
  * <li>Optionally triggers context compaction if the configured trigger fires.</li>
  * </ol>
  *
@@ -77,6 +80,8 @@ import org.springframework.util.Assert;
  * @since 2.0.0
  */
 public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
+
+	private static final Logger logger = LoggerFactory.getLogger(SessionMemoryAdvisor.class);
 
 	/**
 	 * Context key used to pass the session ID into the advisor per-request. Equals
@@ -200,15 +205,23 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 		String sessionId = getSessionId(response.context());
 
 		// 1. Append the assistant message(s) produced by the model. Empty frames —
-		// blank text and no tool calls — are not stored. Some models (e.g. Bedrock
-		// Converse) emit such a frame to signal end_turn after a tool-call sequence;
-		// replaying it on the next request causes a validation error on those models.
+		// blank text, no tool calls, and no media — are not stored. Some models
+		// (e.g. Bedrock Converse) emit such a frame to signal end_turn after a
+		// tool-call sequence; replaying it on the next request causes a validation
+		// error on those models.
 		if (response.chatResponse() != null) {
 			response.chatResponse()
 				.getResults()
 				.stream()
 				.map(g -> (Message) g.getOutput())
-				.filter(msg -> !isEmptyAssistantMessage(msg))
+				.filter(msg -> {
+					if (isEmptyAssistantMessage(msg)) {
+						logger.warn("Skipping empty assistant message for session [{}] — no text, tool calls, or media",
+								sessionId);
+						return false;
+					}
+					return true;
+				})
 				.forEach(msg -> this.sessionService.appendMessage(sessionId, msg));
 		}
 
@@ -251,16 +264,20 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 	}
 
 	/**
-	 * Returns {@code true} for an {@link AssistantMessage} that carries neither text
-	 * nor tool calls. Such messages are implementation artifacts emitted by some models
-	 * (e.g. Bedrock Converse {@code end_turn} after a tool-call sequence) and carry no
-	 * conversational value. Storing and replaying them causes validation errors on those
-	 * same models.
+	 * Returns {@code true} for an {@link AssistantMessage} that carries neither text,
+	 * tool calls, nor media content. Such messages are implementation artifacts emitted
+	 * by some models (e.g. Bedrock Converse {@code end_turn} after a tool-call sequence)
+	 * and carry no conversational value. Storing and replaying them causes validation
+	 * errors on those same models.
+	 * <p>
+	 * Messages that carry media (e.g. image outputs from multimodal models) are
+	 * intentionally preserved even when their text is blank.
 	 */
 	private static boolean isEmptyAssistantMessage(Message message) {
 		return message instanceof AssistantMessage am
 				&& (am.getText() == null || am.getText().isBlank())
-				&& !am.hasToolCalls();
+				&& !am.hasToolCalls()
+				&& CollectionUtils.isEmpty(am.getMedia());
 	}
 
 	public static Builder builder(SessionService sessionService) {

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
@@ -332,6 +332,101 @@ class SessionMemoryAdvisorIT {
 		assertThat(texts).contains("only message");
 	}
 
+	// --- Empty assistant message filtering ---
+
+	@Test
+	void afterDoesNotStoreAssistantMessageWithBlankText() {
+		// Bedrock Converse emits AssistantMessage("") to signal end_turn after tool use.
+		// It must not be stored; replaying it on the next request causes a
+		// ValidationException on Bedrock.
+		ChatClientResponse response = buildResponseFromMessages(this.sessionId,
+				new AssistantMessage(""));
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		assertThat(this.sessionService.getEvents(this.sessionId)).isEmpty();
+	}
+
+	@Test
+	void afterDoesNotStoreAssistantMessageWithWhitespaceOnlyText() {
+		ChatClientResponse response = buildResponseFromMessages(this.sessionId,
+				new AssistantMessage("   "));
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		assertThat(this.sessionService.getEvents(this.sessionId)).isEmpty();
+	}
+
+	@Test
+	void afterStoresAssistantMessageWithText() {
+		// Regression guard: normal assistant messages must still be stored.
+		ChatClientResponse response = buildResponse(this.sessionId, "Paris is the capital of France.");
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		List<SessionEvent> events = this.sessionService.getEvents(this.sessionId);
+		assertThat(events).hasSize(1);
+		assertThat(events.get(0).getMessage().getText()).isEqualTo("Paris is the capital of France.");
+	}
+
+	@Test
+	void afterStoresAssistantMessageWithToolCallsEvenWhenTextIsBlank() {
+		// An AssistantMessage with tool calls but no text is a real tool-invocation
+		// event — it must not be filtered out.
+		AssistantMessage withToolCalls = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"city\":\"Paris\"}")))
+			.build();
+		ChatClientResponse response = buildResponseFromMessages(this.sessionId, withToolCalls);
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		List<SessionEvent> events = this.sessionService.getEvents(this.sessionId);
+		assertThat(events).hasSize(1);
+		assertThat(events.get(0).hasToolCalls()).isTrue();
+	}
+
+	@Test
+	void afterStoresOnlyNonEmptyMessagesFromMultiGenerationResponse() {
+		// Bedrock scenario: the model response contains two generations — the real
+		// tool-call invocation followed by an empty end_turn frame. Only the tool-call
+		// generation must be persisted.
+		AssistantMessage toolCallMessage = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"city\":\"Paris\"}")))
+			.build();
+		AssistantMessage emptyEndTurn = new AssistantMessage("");
+
+		ChatClientResponse response = buildResponseFromMessages(this.sessionId, toolCallMessage, emptyEndTurn);
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		List<SessionEvent> events = this.sessionService.getEvents(this.sessionId);
+		assertThat(events).hasSize(1);
+		assertThat(events.get(0).hasToolCalls()).isTrue();
+	}
+
+	@Test
+	void emptyEndTurnMessageIsNotReplayedOnNextTurn() {
+		// Full Bedrock tool-call round-trip:
+		//   turn 1 before()  → user message stored
+		//   turn 1 after()   → ASSISTANT[tool calls] stored, ASSISTANT[""] skipped
+		//   turn 2 before()  → history injected into prompt must not contain the empty frame
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		// Turn 1
+		this.advisor.before(buildRequest(this.sessionId, "What is the weather in Paris?"), chain);
+
+		AssistantMessage toolCallMessage = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"city\":\"Paris\"}")))
+			.build();
+		AssistantMessage emptyEndTurn = new AssistantMessage("");
+		this.advisor.after(buildResponseFromMessages(this.sessionId, toolCallMessage, emptyEndTurn), chain);
+
+		// Turn 2 — inspect the prompt that the advisor builds
+		ChatClientRequest modified = this.advisor.before(buildRequest(this.sessionId, "Thanks!"), chain);
+
+		List<String> texts = modified.prompt().getInstructions().stream().map(Message::getText).toList();
+		// The empty end_turn frame must not appear in the injected history
+		assertThat(texts).doesNotContain("");
+		assertThat(texts).doesNotContain("   ");
+		// Real events are still present
+		assertThat(texts).contains("What is the weather in Paris?");
+	}
+
 	// --- Builder validation ---
 
 	@Test
@@ -373,6 +468,20 @@ class SessionMemoryAdvisorIT {
 		ChatResponse chatResponse = ChatResponse.builder()
 			.generations(List.of(new Generation(new AssistantMessage(assistantText))))
 			.build();
+		return ChatClientResponse.builder()
+			.chatResponse(chatResponse)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, sessionId))
+			.build();
+	}
+
+	/**
+	 * Builds a response whose {@code ChatResponse} contains one {@code Generation} per
+	 * supplied {@link AssistantMessage}. Use this to simulate multi-generation responses
+	 * such as the Bedrock Converse end_turn pattern (tool-call frame + empty frame).
+	 */
+	private static ChatClientResponse buildResponseFromMessages(String sessionId, AssistantMessage... messages) {
+		List<Generation> generations = List.of(messages).stream().map(Generation::new).toList();
+		ChatResponse chatResponse = ChatResponse.builder().generations(generations).build();
 		return ChatClientResponse.builder()
 			.chatResponse(chatResponse)
 			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, sessionId))

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.session.advisor;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +39,7 @@ import org.springframework.ai.session.Session;
 import org.springframework.ai.session.SessionEvent;
 import org.springframework.ai.session.SessionRepository;
 import org.springframework.ai.session.SessionService;
+import org.springframework.ai.content.Media;
 import org.springframework.ai.session.compaction.SlidingWindowCompactionStrategy;
 import org.springframework.ai.session.compaction.TurnCountTrigger;
 import org.springframework.ai.session.DefaultSessionService;
@@ -46,6 +48,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -425,6 +428,52 @@ class SessionMemoryAdvisorIT {
 		assertThat(texts).doesNotContain("   ");
 		// Real events are still present
 		assertThat(texts).contains("What is the weather in Paris?");
+	}
+
+	// --- Multimodal assistant message filtering ---
+
+	@Test
+	void afterStoresAssistantMessageWithMediaEvenWhenTextIsBlank() {
+		// A multimodal model may respond with an image (or other media) and no text.
+		// That is a valid, content-bearing message and must NOT be dropped.
+		Media image = new Media(MimeTypeUtils.IMAGE_PNG, URI.create("https://example.com/image.png"));
+		AssistantMessage withMedia = AssistantMessage.builder()
+			.media(List.of(image))
+			.build();
+		ChatClientResponse response = buildResponseFromMessages(this.sessionId, withMedia);
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		List<SessionEvent> events = this.sessionService.getEvents(this.sessionId);
+		assertThat(events).hasSize(1);
+		assertThat(events.get(0).getMessage()).isInstanceOf(AssistantMessage.class);
+		assertThat(((AssistantMessage) events.get(0).getMessage()).getMedia()).hasSize(1);
+	}
+
+	@Test
+	void afterStoresAssistantMessageWithMediaAndToolCallsEvenWhenTextIsBlank() {
+		// Pathological but legal: a message with both media and tool calls, no text.
+		// Both signals independently mark it as non-empty — it must be preserved.
+		Media image = new Media(MimeTypeUtils.IMAGE_PNG, URI.create("https://example.com/image.png"));
+		AssistantMessage withBoth = AssistantMessage.builder()
+			.media(List.of(image))
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "describe_image", "{}")))
+			.build();
+		ChatClientResponse response = buildResponseFromMessages(this.sessionId, withBoth);
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		List<SessionEvent> events = this.sessionService.getEvents(this.sessionId);
+		assertThat(events).hasSize(1);
+		assertThat(events.get(0).hasToolCalls()).isTrue();
+	}
+
+	@Test
+	void afterDropsAssistantMessageWithNullTextNoToolCallsAndNoMedia() {
+		// Explicit null text (not just blank) with no other content — must be dropped.
+		AssistantMessage nullText = AssistantMessage.builder().build();
+		ChatClientResponse response = buildResponseFromMessages(this.sessionId, nullText);
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		assertThat(this.sessionService.getEvents(this.sessionId)).isEmpty();
 	}
 
 	// --- Builder validation ---


### PR DESCRIPTION
## Problem

`SessionMemoryAdvisor` was storing every `AssistantMessage` produced by the model, including empty frames that carry neither text nor tool calls. AWS Bedrock Converse emits such a frame (`end_turn`) at the end of a tool-call sequence. When this empty message was replayed into the next request as part of the injected session history, Bedrock rejected it with a `ValidationException`.

Fixes #10

## Solution

Added a `isEmptyAssistantMessage(Message)` predicate in `after()` that filters out `AssistantMessage` instances where:
- `getText()` is `null` or blank, **and**
- `hasToolCalls()` is `false`

Tool-call messages that happen to carry no text body are intentionally preserved — they are real invocation events that must remain in history.

## Test coverage

Six new tests added in `SessionMemoryAdvisorIT`:

| Test | Scenario |
|---|---|
| `afterDoesNotStoreAssistantMessageWithBlankText` | `AssistantMessage("")` is not stored |
| `afterDoesNotStoreAssistantMessageWithWhitespaceOnlyText` | `AssistantMessage("   ")` is not stored |
| `afterStoresAssistantMessageWithText` | Regression guard — normal messages still stored |
| `afterStoresAssistantMessageWithToolCallsEvenWhenTextIsBlank` | Tool-call messages without text are preserved |
| `afterStoresOnlyNonEmptyMessagesFromMultiGenerationResponse` | Mixed response: real tool-call frame + empty end_turn frame — only real one stored |
| `emptyEndTurnMessageIsNotReplayedOnNextTurn` | Full Bedrock round-trip: empty frame absent from history injected on the next turn |

## Checklist

- [x] Bug reproduced and root cause identified
- [x] Fix is minimal and scoped to the `after()` path
- [x] All new tests pass
- [x] Streaming path covered (uses same `after()` via `ChatClientMessageAggregator`)
- [x] `Signed-off-by` present

Signed-off-by: kuntal1461 <kuntal.1461@gmail.com>