### PR TITLE
Use `@Nullable` for `SessionRepository#findById`

### DIFF
--- a/auto-configurations/session/spring-ai-autoconfigure-session-jdbc/src/test/java/org/springaicommunity/session/jdbc/autoconfigure/JdbcSessionRepositoryMysqlAutoConfigurationIT.java
+++ b/auto-configurations/session/spring-ai-autoconfigure-session-jdbc/src/test/java/org/springaicommunity/session/jdbc/autoconfigure/JdbcSessionRepositoryMysqlAutoConfigurationIT.java
@@ -75,8 +75,8 @@ class JdbcSessionRepositoryMysqlAutoConfigurationIT {
 
 			repo.save(session);
 
-			assertThat(repo.findById(sessionId)).isPresent()
-				.hasValueSatisfying(s -> assertThat(s.userId()).isEqualTo("user-mysql"));
+			assertThat(repo.findById(sessionId)).isNotNull()
+				.satisfies(s -> assertThat(s.userId()).isEqualTo("user-mysql"));
 		});
 	}
 
@@ -126,7 +126,7 @@ class JdbcSessionRepositoryMysqlAutoConfigurationIT {
 
 			repo.delete(sessionId);
 
-			assertThat(repo.findById(sessionId)).isEmpty();
+			assertThat(repo.findById(sessionId)).isNull();
 		});
 	}
 

--- a/auto-configurations/session/spring-ai-autoconfigure-session-jdbc/src/test/java/org/springaicommunity/session/jdbc/autoconfigure/JdbcSessionRepositoryPostgresqlAutoConfigurationIT.java
+++ b/auto-configurations/session/spring-ai-autoconfigure-session-jdbc/src/test/java/org/springaicommunity/session/jdbc/autoconfigure/JdbcSessionRepositoryPostgresqlAutoConfigurationIT.java
@@ -75,8 +75,8 @@ class JdbcSessionRepositoryPostgresqlAutoConfigurationIT {
 
 			repo.save(session);
 
-			assertThat(repo.findById(sessionId)).isPresent()
-				.hasValueSatisfying(s -> assertThat(s.userId()).isEqualTo("user-pg"));
+			assertThat(repo.findById(sessionId)).isNotNull()
+				.satisfies(s -> assertThat(s.userId()).isEqualTo("user-pg"));
 		});
 	}
 
@@ -126,7 +126,7 @@ class JdbcSessionRepositoryPostgresqlAutoConfigurationIT {
 
 			repo.delete(sessionId);
 
-			assertThat(repo.findById(sessionId)).isEmpty();
+			assertThat(repo.findById(sessionId)).isNull();
 		});
 	}
 

--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.sql.DataSource;
 
@@ -173,10 +172,10 @@ public final class JdbcSessionRepository implements SessionRepository {
 	}
 
 	@Override
-	public Optional<Session> findById(String sessionId) {
+	public @Nullable Session findById(String sessionId) {
 		Assert.hasText(sessionId, "sessionId must not be null or empty");
 		List<Session> results = this.jdbcTemplate.query(SELECT_SESSION_BY_ID, new SessionRowMapper(), sessionId);
-		return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+		return results.isEmpty() ? null : results.get(0);
 	}
 
 	@Override

--- a/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
+++ b/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
@@ -18,7 +18,6 @@ package org.springframework.ai.session.jdbc;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -86,10 +85,10 @@ class JdbcSessionRepositoryTests {
 		Session session = buildSession("user-1");
 		this.repository.save(session);
 
-		Optional<Session> found = this.repository.findById(session.id());
-		assertThat(found).isPresent();
-		assertThat(found.get().id()).isEqualTo(session.id());
-		assertThat(found.get().userId()).isEqualTo("user-1");
+		Session found = this.repository.findById(session.id());
+		assertThat(found).isNotNull();
+		assertThat(found.id()).isEqualTo(session.id());
+		assertThat(found.userId()).isEqualTo("user-1");
 	}
 
 	@Test
@@ -103,7 +102,8 @@ class JdbcSessionRepositoryTests {
 			.build();
 		this.repository.save(session);
 
-		Session found = this.repository.findById(session.id()).orElseThrow();
+		Session found = this.repository.findById(session.id());
+		assertThat(found).isNotNull();
 		assertThat(found.expiresAt()).isNotNull();
 		assertThat(found.expiresAt().toEpochMilli()).isEqualTo(expiry.toEpochMilli());
 		assertThat(found.metadata()).containsEntry("model", "gpt-4o");
@@ -124,15 +124,16 @@ class JdbcSessionRepositoryTests {
 			.build();
 		this.repository.save(updated);
 
-		Session found = this.repository.findById(session.id()).orElseThrow();
+		Session found = this.repository.findById(session.id());
+		assertThat(found).isNotNull();
 		assertThat(found.metadata()).containsEntry("newKey", "newVal");
 		assertThat(this.repository.getEventVersion(session.id())).isEqualTo(versionAfterAppend);
 		assertThat(this.repository.findEvents(session.id(), EventFilter.all())).hasSize(1);
 	}
 
 	@Test
-	void findByIdReturnsEmptyWhenNotFound() {
-		assertThat(this.repository.findById("no-such-id")).isEmpty();
+	void findByIdReturnsNullWhenNotFound() {
+		assertThat(this.repository.findById("no-such-id")).isNull();
 	}
 
 	@Test
@@ -154,7 +155,7 @@ class JdbcSessionRepositoryTests {
 
 		this.repository.delete(session.id());
 
-		assertThat(this.repository.findById(session.id())).isEmpty();
+		assertThat(this.repository.findById(session.id())).isNull();
 		assertThat(this.repository.findEvents(session.id(), EventFilter.all())).isEmpty();
 	}
 

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/DefaultSessionService.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/DefaultSessionService.java
@@ -67,7 +67,7 @@ public class DefaultSessionService implements SessionService {
 	@Nullable public Session findById(String sessionId) {
 		Assert.hasText(sessionId, "sessionId must not be null or empty");
 
-		return this.sessionRepository.findById(sessionId).orElse(null);
+		return this.sessionRepository.findById(sessionId);
 	}
 
 	@Override
@@ -109,8 +109,10 @@ public class DefaultSessionService implements SessionService {
 		Assert.notNull(trigger, "trigger must not be null");
 		Assert.notNull(strategy, "strategy must not be null");
 
-		Session session = this.sessionRepository.findById(sessionId)
-			.orElseThrow(() -> new IllegalArgumentException("Session not found: " + sessionId));
+		Session session = this.sessionRepository.findById(sessionId);
+		if (session == null) {
+			throw new IllegalArgumentException("Session not found: " + sessionId);
+		}
 
 		return compactWith(session, trigger, strategy);
 	}

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/InMemorySessionRepository.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/InMemorySessionRepository.java
@@ -20,9 +20,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.util.Assert;
 
@@ -65,10 +66,10 @@ public final class InMemorySessionRepository implements SessionRepository {
 	}
 
 	@Override
-	public Optional<Session> findById(String sessionId) {
+	public @Nullable Session findById(String sessionId) {
 		Assert.hasText(sessionId, "sessionId must not be null or empty");
 		SessionData data = this.store.get(sessionId);
-		return Optional.ofNullable(data).map(SessionData::session);
+		return (data != null) ? data.session() : null;
 	}
 
 	@Override

--- a/spring-ai-session-management/src/main/java/org/springframework/ai/session/SessionRepository.java
+++ b/spring-ai-session-management/src/main/java/org/springframework/ai/session/SessionRepository.java
@@ -18,7 +18,8 @@ package org.springframework.ai.session;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Persistence contract for {@link Session} objects and their event logs.
@@ -41,7 +42,7 @@ public interface SessionRepository {
 	 */
 	Session save(Session session);
 
-	Optional<Session> findById(String sessionId);
+	@Nullable Session findById(String sessionId);
 
 	List<Session> findByUserId(String userId);
 

--- a/spring-ai-session-management/src/test/java/org/springframework/ai/session/InMemorySessionRepositoryTests.java
+++ b/spring-ai-session-management/src/test/java/org/springframework/ai/session/InMemorySessionRepositoryTests.java
@@ -18,7 +18,6 @@ package org.springframework.ai.session;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -47,16 +46,16 @@ class InMemorySessionRepositoryTests {
 		Session session = buildSession("user-1");
 
 		Session saved = this.repository.save(session);
-		Optional<Session> found = this.repository.findById(saved.id());
+		Session found = this.repository.findById(saved.id());
 
-		assertThat(found).isPresent();
-		assertThat(found.get().id()).isEqualTo(saved.id());
-		assertThat(found.get().userId()).isEqualTo("user-1");
+		assertThat(found).isNotNull();
+		assertThat(found.id()).isEqualTo(saved.id());
+		assertThat(found.userId()).isEqualTo("user-1");
 	}
 
 	@Test
-	void findByIdReturnsEmptyWhenNotFound() {
-		assertThat(this.repository.findById("no-such-id")).isEmpty();
+	void findByIdReturnsNullWhenNotFound() {
+		assertThat(this.repository.findById("no-such-id")).isNull();
 	}
 
 	@Test
@@ -115,7 +114,7 @@ class InMemorySessionRepositoryTests {
 
 		this.repository.delete(session.id());
 
-		assertThat(this.repository.findById(session.id())).isEmpty();
+		assertThat(this.repository.findById(session.id())).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
Looks more idiomatic now that the whole portfolio is using JSpecify, also provides better performance.