### PR TITLE
Add MongoDB SessionRepository implementation #26

### DIFF
--- a/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/pom.xml
+++ b/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springaicommunity</groupId>
+        <artifactId>spring-ai-session-parent</artifactId>
+        <version>0.6.0-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>spring-ai-autoconfigure-session-mongodb</artifactId>
+    <version>0.6.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Spring AI Session MongoDB Auto Configuration</name>
+    <description>Spring AI MongoDB-backed Session Repository Auto Configuration</description>
+
+    <url>https://github.com/spring-ai-community/spring-ai-session</url>
+
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-session</url>
+        <connection>scm:git:git://github.com/spring-ai-community/spring-ai-session.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/spring-ai-community/spring-ai-session.git</developerConnection>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-session-mongodb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-autoconfigure-session</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Boot dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/main/java/org/springaicommunity/session/mongodb/autoconfigure/MongoSessionRepositoryAutoConfiguration.java
+++ b/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/main/java/org/springaicommunity/session/mongodb/autoconfigure/MongoSessionRepositoryAutoConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.session.mongodb.autoconfigure;
+
+import com.mongodb.client.MongoClient;
+
+import org.springframework.ai.session.mongodb.MongoSessionRepository;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ * Auto-configuration for {@link MongoSessionRepository}.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnClass({ MongoSessionRepository.class, MongoClient.class, MongoTemplate.class })
+@EnableConfigurationProperties(MongoSessionRepositoryProperties.class)
+public class MongoSessionRepositoryAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	MongoSessionRepository mongoSessionRepository(MongoTemplate mongoTemplate) {
+		return MongoSessionRepository.builder().mongoTemplate(mongoTemplate).build();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = MongoSessionRepositoryProperties.CONFIG_PREFIX, name = "initialize-schema",
+			havingValue = "true", matchIfMissing = true)
+	MongoSessionRepositorySchemaInitializer mongoSessionRepositorySchemaInitializer(MongoTemplate mongoTemplate,
+			MongoSessionRepositoryProperties properties) {
+		return new MongoSessionRepositorySchemaInitializer(mongoTemplate);
+	}
+
+}

--- a/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/main/java/org/springaicommunity/session/mongodb/autoconfigure/MongoSessionRepositoryProperties.java
+++ b/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/main/java/org/springaicommunity/session/mongodb/autoconfigure/MongoSessionRepositoryProperties.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.session.mongodb.autoconfigure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the MongoDB-backed
+ * {@link org.springframework.ai.session.mongodb.MongoSessionRepository}.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+@ConfigurationProperties(MongoSessionRepositoryProperties.CONFIG_PREFIX)
+public class MongoSessionRepositoryProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.session.repository.mongodb";
+
+	/**
+	 * Whether to initialize the required collections and indexes on startup.
+	 */
+	private boolean initializeSchema = true;
+
+	public boolean isInitializeSchema() {
+		return this.initializeSchema;
+	}
+
+	public void setInitializeSchema(boolean initializeSchema) {
+		this.initializeSchema = initializeSchema;
+	}
+
+}

--- a/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/main/java/org/springaicommunity/session/mongodb/autoconfigure/MongoSessionRepositorySchemaInitializer.java
+++ b/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/main/java/org/springaicommunity/session/mongodb/autoconfigure/MongoSessionRepositorySchemaInitializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.session.mongodb.autoconfigure;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+
+/**
+ * Performs collection and index initialization for the MongoDB Session Repository.
+ *
+ * <p>
+ * Creates indexes on the {@code ai_sessions} and {@code ai_session_events} collections to
+ * optimize the most common query patterns:
+ * <ul>
+ * <li>{@code ai_sessions.userId} — for {@code findByUserId}</li>
+ * <li>{@code ai_sessions.expiresAt} — for {@code findExpiredSessionIds}</li>
+ * <li>{@code ai_session_events.sessionId + seq} — for ordered event retrieval</li>
+ * </ul>
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+class MongoSessionRepositorySchemaInitializer implements InitializingBean {
+
+	private static final Logger logger = LoggerFactory.getLogger(MongoSessionRepositorySchemaInitializer.class);
+
+	private static final String COLLECTION_SESSIONS = "ai_sessions";
+
+	private static final String COLLECTION_EVENTS = "ai_session_events";
+
+	private final MongoTemplate mongoTemplate;
+
+	MongoSessionRepositorySchemaInitializer(MongoTemplate mongoTemplate) {
+		this.mongoTemplate = mongoTemplate;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		IndexOperations sessionIndexOps = this.mongoTemplate.indexOps(COLLECTION_SESSIONS);
+		sessionIndexOps.ensureIndex(new Index().on("userId", Sort.Direction.ASC).named("idx_userId"));
+		sessionIndexOps.ensureIndex(new Index().on("expiresAt", Sort.Direction.ASC).named("idx_expiresAt"));
+
+		IndexOperations eventIndexOps = this.mongoTemplate.indexOps(COLLECTION_EVENTS);
+		eventIndexOps.ensureIndex(
+				new Index().on("sessionId", Sort.Direction.ASC).on("seq", Sort.Direction.ASC).named("idx_sessionId_seq"));
+		eventIndexOps.ensureIndex(new Index().on("sessionId", Sort.Direction.ASC).on("archived", Sort.Direction.ASC)
+			.named("idx_sessionId_archived"));
+
+		logger.info("Initialized MongoDB collections and indexes for Spring AI Session");
+	}
+
+}

--- a/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2023-present the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.springaicommunity.session.mongodb.autoconfigure.MongoSessionRepositoryAutoConfiguration

--- a/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/test/java/org/springaicommunity/session/mongodb/autoconfigure/MongoSessionRepositoryAutoConfigurationTests.java
+++ b/auto-configurations/session/spring-ai-autoconfigure-session-mongodb/src/test/java/org/springaicommunity/session/mongodb/autoconfigure/MongoSessionRepositoryAutoConfigurationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.session.mongodb.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.ai.session.SessionService;
+import org.springframework.ai.session.mongodb.MongoSessionRepository;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springaicommunity.session.autoconfigure.SessionServiceAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MongoSessionRepositoryAutoConfiguration}.
+ *
+ * @author Christian Tzolov
+ */
+@Testcontainers
+class MongoSessionRepositoryAutoConfigurationTests {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7");
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withBean(MongoTemplate.class,
+				() -> new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongo.getConnectionString())))
+		.withConfiguration(AutoConfigurations.of(MongoSessionRepositoryAutoConfiguration.class,
+				SessionServiceAutoConfiguration.class));
+
+	@Test
+	void mongoSessionRepositoryBeanIsCreated() {
+		this.contextRunner.run(context -> assertThat(context).hasSingleBean(MongoSessionRepository.class));
+	}
+
+	@Test
+	void sessionServiceBeanIsCreated() {
+		this.contextRunner.run(context -> assertThat(context).hasSingleBean(SessionService.class));
+	}
+
+	@Test
+	void schemaInitializerBeanIsCreated() {
+		this.contextRunner
+			.run(context -> assertThat(context).hasSingleBean(MongoSessionRepositorySchemaInitializer.class));
+	}
+
+	@Test
+	void schemaInitializerNotCreatedWhenDisabled() {
+		this.contextRunner
+			.withPropertyValues(MongoSessionRepositoryProperties.CONFIG_PREFIX + ".initialize-schema=false")
+			.run(context -> assertThat(context).doesNotHaveBean(MongoSessionRepositorySchemaInitializer.class));
+	}
+
+	@Test
+	void customRepositoryBeanIsRespected() {
+		this.contextRunner
+			.withBean(MongoSessionRepository.class,
+					() -> MongoSessionRepository.builder()
+						.mongoTemplate(new MongoTemplate(
+								new SimpleMongoClientDatabaseFactory(mongo.getConnectionString())))
+						.build())
+			.run(context -> assertThat(context).hasSingleBean(MongoSessionRepository.class));
+	}
+
+	@Test
+	void defaultProperties() {
+		var props = new MongoSessionRepositoryProperties();
+		assertThat(props.isInitializeSchema()).isTrue();
+	}
+
+}

--- a/auto-configurations/session/spring-ai-autoconfigure-session/src/main/java/org/springaicommunity/session/autoconfigure/SessionServiceAutoConfiguration.java
+++ b/auto-configurations/session/spring-ai-autoconfigure-session/src/main/java/org/springaicommunity/session/autoconfigure/SessionServiceAutoConfiguration.java
@@ -42,8 +42,8 @@ import org.springframework.context.annotation.Bean;
  * @author Christian Tzolov
  * @since 2.0.0
  */
-@AutoConfiguration(
-		afterName = "org.springaicommunity.session.jdbc.autoconfigure.JdbcSessionRepositoryAutoConfiguration")
+@AutoConfiguration(afterName = { "org.springaicommunity.session.jdbc.autoconfigure.JdbcSessionRepositoryAutoConfiguration",
+		"org.springaicommunity.session.mongodb.autoconfigure.MongoSessionRepositoryAutoConfiguration" })
 @ConditionalOnClass(SessionService.class)
 @ConditionalOnBean(SessionRepository.class)
 @ConditionalOnMissingBean(SessionService.class)

--- a/boot-starters/spring-ai-starter-session-mongodb/pom.xml
+++ b/boot-starters/spring-ai-starter-session-mongodb/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springaicommunity</groupId>
+        <artifactId>spring-ai-session-parent</artifactId>
+        <version>0.6.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>spring-ai-starter-session-mongodb</artifactId>
+    <version>0.6.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Spring AI Starter - Session MongoDB</name>
+    <description>Spring Boot starter for MongoDB-backed Spring AI Session management</description>
+
+    <url>https://github.com/spring-ai-community/spring-ai-session</url>
+
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-session</url>
+        <connection>scm:git:git://github.com/spring-ai-community/spring-ai-session.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/spring-ai-community/spring-ai-session.git</developerConnection>
+    </scm>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-autoconfigure-session</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-autoconfigure-session-mongodb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-session-mongodb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,12 @@
         <module>spring-ai-session-bom</module>
         <module>spring-ai-session</module>
         <module>spring-ai-session-jdbc</module>
+        <module>spring-ai-session-mongodb</module>
         <module>auto-configurations/session/spring-ai-autoconfigure-session</module>
         <module>auto-configurations/session/spring-ai-autoconfigure-session-jdbc</module>
+        <module>auto-configurations/session/spring-ai-autoconfigure-session-mongodb</module>
         <module>boot-starters/spring-ai-starter-session-jdbc</module>
+        <module>boot-starters/spring-ai-starter-session-mongodb</module>
     </modules>
 
     <properties>

--- a/spring-ai-session-bom/pom.xml
+++ b/spring-ai-session-bom/pom.xml
@@ -84,6 +84,11 @@
             </dependency>
             <dependency>
                 <groupId>org.springaicommunity</groupId>
+                <artifactId>spring-ai-session-mongodb</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springaicommunity</groupId>
                 <artifactId>spring-ai-autoconfigure-session</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -94,7 +99,17 @@
             </dependency>
             <dependency>
                 <groupId>org.springaicommunity</groupId>
+                <artifactId>spring-ai-autoconfigure-session-mongodb</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springaicommunity</groupId>
                 <artifactId>spring-ai-starter-session-jdbc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springaicommunity</groupId>
+                <artifactId>spring-ai-starter-session-mongodb</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>

--- a/spring-ai-session-mongodb/pom.xml
+++ b/spring-ai-session-mongodb/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springaicommunity</groupId>
+        <artifactId>spring-ai-session-parent</artifactId>
+        <version>0.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>spring-ai-session-mongodb</artifactId>
+    <version>0.6.0-SNAPSHOT</version>
+
+    <name>Spring AI Session MongoDB</name>
+    <description>MongoDB-backed SessionRepository implementation for Spring AI Session</description>
+
+    <url>https://github.com/spring-ai-community/spring-ai-session</url>
+
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-session</url>
+        <connection>scm:git:git://github.com/spring-ai-community/spring-ai-session.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/spring-ai-community/spring-ai-session.git</developerConnection>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-session</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-ai-session-mongodb/src/main/java/org/springframework/ai/session/mongodb/MongoSessionRepository.java
+++ b/spring-ai-session-mongodb/src/main/java/org/springframework/ai/session/mongodb/MongoSessionRepository.java
@@ -1,0 +1,553 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.mongodb;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bson.Document;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.session.EventFilter;
+import org.springframework.ai.session.Session;
+import org.springframework.ai.session.SessionEvent;
+import org.springframework.ai.session.SessionRepository;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.util.Assert;
+
+/**
+ * MongoDB-backed implementation of {@link SessionRepository} using Spring Data MongoDB.
+ *
+ * <h2>Collections</h2>
+ * <p>
+ * Two collections are required:
+ * <ul>
+ * <li>{@code ai_sessions} — session metadata (id, userId, createdAt, expiresAt, metadata,
+ * eventVersion, eventSeq)</li>
+ * <li>{@code ai_session_events} — append-only event log</li>
+ * </ul>
+ *
+ * <h2>Message serialization</h2>
+ * <p>
+ * Each {@link SessionEvent}'s wrapped {@link Message} is stored across three fields:
+ * <ul>
+ * <li>{@code messageType} — the {@link MessageType} name</li>
+ * <li>{@code messageContent} — plain text ({@code message.getText()})</li>
+ * <li>{@code messageData} — JSON string for type-specific structured data
+ * ({@link AssistantMessage.ToolCall} list or {@link ToolResponseMessage.ToolResponse}
+ * list)</li>
+ * </ul>
+ *
+ * <h2>Optimistic concurrency (CAS)</h2>
+ * <p>
+ * The {@code eventVersion} field in {@code ai_sessions} is incremented atomically on
+ * every {@link #appendEvent} and {@link #compactEvents} call. {@code compactEvents} guards
+ * compaction by issuing a conditional {@code findAndModify} that matches
+ * {@code eventVersion = expectedVersion} first; if no document matches, the swap is
+ * abandoned and {@code false} is returned.
+ *
+ * <h2>Event ordering</h2>
+ * <p>
+ * Events are ordered by a monotonically increasing {@code seq} field, which reflects
+ * insertion order (the logical conversation order) rather than wall-clock
+ * {@code timestamp}. This keeps a synthetic compaction summary — whose timestamp is the
+ * compaction time — correctly positioned ahead of the older active-window events it
+ * precedes. The {@code seq} value is sourced from an {@code eventSeq} counter on the
+ * session document that is atomically incremented via {@code $inc}.
+ *
+ * <h2>Thread safety</h2>
+ * <p>
+ * All mutating operations use atomic MongoDB operations ({@code $inc},
+ * {@code findAndModify}). The class is thread-safe as long as the underlying
+ * {@link MongoTemplate} is.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public final class MongoSessionRepository implements SessionRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(MongoSessionRepository.class);
+
+	private static final String COLLECTION_SESSIONS = "ai_sessions";
+
+	private static final String COLLECTION_EVENTS = "ai_session_events";
+
+	private static final String FIELD_ID = "_id";
+
+	private static final String FIELD_USER_ID = "userId";
+
+	private static final String FIELD_CREATED_AT = "createdAt";
+
+	private static final String FIELD_EXPIRES_AT = "expiresAt";
+
+	private static final String FIELD_METADATA = "metadata";
+
+	private static final String FIELD_EVENT_VERSION = "eventVersion";
+
+	private static final String FIELD_EVENT_SEQ = "eventSeq";
+
+	private static final String FIELD_SESSION_ID = "sessionId";
+
+	private static final String FIELD_TIMESTAMP = "timestamp";
+
+	private static final String FIELD_MESSAGE_TYPE = "messageType";
+
+	private static final String FIELD_MESSAGE_CONTENT = "messageContent";
+
+	private static final String FIELD_MESSAGE_DATA = "messageData";
+
+	private static final String FIELD_SYNTHETIC = "synthetic";
+
+	private static final String FIELD_ARCHIVED = "archived";
+
+	private static final String FIELD_BRANCH = "branch";
+
+	private static final String FIELD_SEQ = "seq";
+
+	private final MongoTemplate mongoTemplate;
+
+	private final JsonMapper jsonMapper;
+
+	private MongoSessionRepository(MongoTemplate mongoTemplate, JsonMapper jsonMapper) {
+		this.mongoTemplate = mongoTemplate;
+		this.jsonMapper = jsonMapper;
+	}
+
+	// -------------------------------------------------------------------------
+	// SessionRepository — session lifecycle
+	// -------------------------------------------------------------------------
+
+	@Override
+	public Session save(Session session) {
+		Assert.notNull(session, "session must not be null");
+		Update update = new Update().set(FIELD_USER_ID, session.userId())
+			.set(FIELD_CREATED_AT, toDate(session.createdAt()))
+			.set(FIELD_EXPIRES_AT, toDate(session.expiresAt()))
+			.set(FIELD_METADATA, session.metadata());
+		this.mongoTemplate.upsert(Query.query(Criteria.where(FIELD_ID).is(session.id())), update, COLLECTION_SESSIONS);
+		return session;
+	}
+
+	@Override
+	public @Nullable Session findById(String sessionId) {
+		Assert.hasText(sessionId, "sessionId must not be null or empty");
+		Document doc = this.mongoTemplate.findOne(Query.query(Criteria.where(FIELD_ID).is(sessionId)), Document.class,
+				COLLECTION_SESSIONS);
+		return (doc != null) ? toSession(doc) : null;
+	}
+
+	@Override
+	public List<Session> findByUserId(String userId) {
+		Assert.hasText(userId, "userId must not be null or empty");
+		List<Document> docs = this.mongoTemplate.find(Query.query(Criteria.where(FIELD_USER_ID).is(userId)),
+				Document.class, COLLECTION_SESSIONS);
+		return docs.stream().map(this::toSession).toList();
+	}
+
+	@Override
+	public List<String> findExpiredSessionIds(Instant before) {
+		Assert.notNull(before, "before must not be null");
+		Query query = Query.query(Criteria.where(FIELD_EXPIRES_AT).ne(null).lt(toDate(before)));
+		query.fields().include(FIELD_ID);
+		return this.mongoTemplate.find(query, Document.class, COLLECTION_SESSIONS)
+			.stream()
+			.map(d -> d.get(FIELD_ID).toString())
+			.toList();
+	}
+
+	@Override
+	public void delete(String sessionId) {
+		Assert.hasText(sessionId, "sessionId must not be null or empty");
+		this.mongoTemplate.remove(Query.query(Criteria.where(FIELD_ID).is(sessionId)), COLLECTION_SESSIONS);
+		this.mongoTemplate.remove(Query.query(Criteria.where(FIELD_SESSION_ID).is(sessionId)), COLLECTION_EVENTS);
+	}
+
+	// -------------------------------------------------------------------------
+	// SessionRepository — event log
+	// -------------------------------------------------------------------------
+
+	@Override
+	public void appendEvent(SessionEvent event) {
+		Assert.notNull(event, "event must not be null");
+		String sessionId = event.getSessionId();
+		requireSessionExists(sessionId);
+		// Atomically claim the next seq value and increment eventVersion in one shot.
+		Document updated = this.mongoTemplate.findAndModify(
+				Query.query(Criteria.where(FIELD_ID).is(sessionId)),
+				new Update().inc(FIELD_EVENT_SEQ, 1).inc(FIELD_EVENT_VERSION, 1),
+				FindAndModifyOptions.options().returnNew(true), Document.class, COLLECTION_SESSIONS);
+		if (updated == null) {
+			throw new IllegalArgumentException("Session not found: " + sessionId);
+		}
+		long seq = ((Number) updated.get(FIELD_EVENT_SEQ)).longValue();
+		insertEvent(event, seq);
+	}
+
+	@Override
+	public boolean compactEvents(String sessionId, List<SessionEvent> archivedEvents,
+			List<SessionEvent> retainedEvents, long expectedVersion) {
+		Assert.hasText(sessionId, "sessionId must not be null or empty");
+		Assert.notNull(archivedEvents, "archivedEvents must not be null");
+		Assert.notNull(retainedEvents, "retainedEvents must not be null");
+		requireSessionExists(sessionId);
+		// Atomically claim the version slot. If another writer already changed it, no
+		// document matches and we bail out without touching the event log.
+		Document updated = this.mongoTemplate.findAndModify(
+				Query.query(Criteria.where(FIELD_ID).is(sessionId).and(FIELD_EVENT_VERSION).is(expectedVersion)),
+				new Update().inc(FIELD_EVENT_VERSION, 1), FindAndModifyOptions.options().returnNew(false), Document.class,
+				COLLECTION_SESSIONS);
+		if (updated == null) {
+			return false;
+		}
+		// Read the previously-archived events (oldest prefix) so they survive the
+		// delete-and-reinsert. The whole log is rebuilt in order so the seq reflects the
+		// logical conversation order: previously-archived events, then newly-archived
+		// events, then the new active window (summary + recent).
+		List<SessionEvent> previouslyArchived = this.mongoTemplate
+			.find(Query.query(Criteria.where(FIELD_SESSION_ID).is(sessionId).and(FIELD_ARCHIVED).is(true))
+				.with(Sort.by(FIELD_SEQ).ascending()), Document.class, COLLECTION_EVENTS)
+			.stream()
+			.map(this::toSessionEvent)
+			.toList();
+		this.mongoTemplate.remove(Query.query(Criteria.where(FIELD_SESSION_ID).is(sessionId)), COLLECTION_EVENTS);
+		// Re-insert all events in order with new seq values: previously-archived, then
+		// newly-archived, then the new active window.
+		long seq = 0;
+		for (SessionEvent e : previouslyArchived) {
+			insertEvent(e, ++seq);
+		}
+		for (SessionEvent e : archivedEvents) {
+			insertEvent(e.asArchived(), ++seq);
+		}
+		for (SessionEvent e : retainedEvents) {
+			insertEvent(e, ++seq);
+		}
+		// Set the seq counter to the last used value so the next appendEvent gets seq+1.
+		this.mongoTemplate.updateFirst(Query.query(Criteria.where(FIELD_ID).is(sessionId)),
+				new Update().set(FIELD_EVENT_SEQ, seq), COLLECTION_SESSIONS);
+		return true;
+	}
+
+	@Override
+	public long getEventVersion(String sessionId) {
+		Assert.hasText(sessionId, "sessionId must not be null or empty");
+		Query query = Query.query(Criteria.where(FIELD_ID).is(sessionId));
+		query.fields().include(FIELD_EVENT_VERSION);
+		Document doc = this.mongoTemplate.findOne(query, Document.class, COLLECTION_SESSIONS);
+		if (doc == null) {
+			return 0L;
+		}
+		Object version = doc.get(FIELD_EVENT_VERSION);
+		return (version instanceof Number n) ? n.longValue() : 0L;
+	}
+
+	@Override
+	public List<SessionEvent> findEvents(String sessionId, EventFilter filter) {
+		Assert.hasText(sessionId, "sessionId must not be null or empty");
+		Assert.notNull(filter, "filter must not be null");
+
+		List<Criteria> criteria = new ArrayList<>();
+		criteria.add(Criteria.where(FIELD_SESSION_ID).is(sessionId));
+
+		if (filter.from() != null) {
+			criteria.add(Criteria.where(FIELD_TIMESTAMP).gte(toDate(filter.from())));
+		}
+		if (filter.to() != null) {
+			criteria.add(Criteria.where(FIELD_TIMESTAMP).lte(toDate(filter.to())));
+		}
+		if (filter.messageTypes() != null && !filter.messageTypes().isEmpty()) {
+			criteria.add(Criteria.where(FIELD_MESSAGE_TYPE).in(filter.messageTypes().stream().map(MessageType::name).toList()));
+		}
+		if (filter.excludeSynthetic()) {
+			criteria.add(Criteria.where(FIELD_SYNTHETIC).is(false));
+		}
+		if (filter.excludeArchived()) {
+			criteria.add(Criteria.where(FIELD_ARCHIVED).is(false));
+		}
+		if (filter.branch() != null) {
+			// Visibility: null branch (root events) OR exact match OR caller is a
+			// descendant (filterBranch starts with eventBranch + '.')
+			criteria.add(new Criteria().orOperator(Criteria.where(FIELD_BRANCH).is(null),
+					Criteria.where(FIELD_BRANCH).is(filter.branch()),
+					Criteria.where(FIELD_BRANCH).regex("^" + java.util.regex.Pattern.quote(filter.branch()) + "\\.")));
+		}
+		if (filter.keyword() != null) {
+			criteria.add(Criteria.where(FIELD_MESSAGE_CONTENT).regex(filter.keyword(), "i"));
+		}
+
+		Query query = Query.query(new Criteria().andOperator(criteria.toArray(new Criteria[0])));
+
+		if (filter.lastN() != null) {
+			query.with(Sort.by(FIELD_SEQ).descending()).limit(filter.lastN());
+		}
+		else if (filter.pageSize() != null) {
+			int page = filter.page() != null ? filter.page() : 0;
+			query.with(Sort.by(FIELD_SEQ).ascending()).skip((long) page * filter.pageSize()).limit(filter.pageSize());
+		}
+		else {
+			query.with(Sort.by(FIELD_SEQ).ascending());
+		}
+
+		List<SessionEvent> result = this.mongoTemplate.find(query, Document.class, COLLECTION_EVENTS)
+			.stream()
+			.map(this::toSessionEvent)
+			.toList();
+
+		if (filter.lastN() != null) {
+			List<SessionEvent> reversed = new ArrayList<>(result);
+			Collections.reverse(reversed);
+			return Collections.unmodifiableList(reversed);
+		}
+
+		return Collections.unmodifiableList(result);
+	}
+
+	// -------------------------------------------------------------------------
+	// Internal helpers
+	// -------------------------------------------------------------------------
+
+	private void insertEvent(SessionEvent event, long seq) {
+		Message msg = event.getMessage();
+		Document doc = new Document(FIELD_ID, event.getId())
+			.append(FIELD_SESSION_ID, event.getSessionId())
+			.append(FIELD_TIMESTAMP, toDate(event.getTimestamp()))
+			.append(FIELD_MESSAGE_TYPE, msg.getMessageType().name())
+			.append(FIELD_MESSAGE_CONTENT, msg.getText())
+			.append(FIELD_MESSAGE_DATA, messageDataToJson(msg))
+			.append(FIELD_SYNTHETIC, event.isSynthetic())
+			.append(FIELD_ARCHIVED, event.isArchived())
+			.append(FIELD_BRANCH, event.getBranch())
+			.append(FIELD_METADATA, event.getMetadata())
+			.append(FIELD_SEQ, seq);
+		this.mongoTemplate.insert(doc, COLLECTION_EVENTS);
+	}
+
+	private void requireSessionExists(String sessionId) {
+		if (!this.mongoTemplate.exists(Query.query(Criteria.where(FIELD_ID).is(sessionId)), COLLECTION_SESSIONS)) {
+			throw new IllegalArgumentException("Session not found: " + sessionId);
+		}
+	}
+
+	@Nullable private Date toDate(@Nullable Instant instant) {
+		return instant != null ? Date.from(instant) : null;
+	}
+
+	@Nullable private Instant toInstant(@Nullable Date date) {
+		return date != null ? date.toInstant() : null;
+	}
+
+	@Nullable private String toJson(@Nullable Object value) {
+		if (value == null) {
+			return null;
+		}
+		try {
+			return this.jsonMapper.writeValueAsString(value);
+		}
+		catch (JacksonException ex) {
+			throw new IllegalStateException("Failed to serialize value to JSON", ex);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> fromJsonMap(@Nullable Object value) {
+		if (value == null) {
+			return Map.of();
+		}
+		if (value instanceof Map<?, ?> map) {
+			Map<String, Object> result = new HashMap<>();
+			map.forEach((k, v) -> result.put(k.toString(), v));
+			return result;
+		}
+		if (value instanceof String json && !json.isBlank()) {
+			try {
+				return this.jsonMapper.readValue(json, new TypeReference<Map<String, Object>>() {
+				});
+			}
+			catch (JacksonException ex) {
+				logger.warn("Failed to deserialize metadata JSON; returning empty map", ex);
+				return new HashMap<>();
+			}
+		}
+		return new HashMap<>();
+	}
+
+	/**
+	 * Serializes type-specific {@link Message} payload to JSON:
+	 * <ul>
+	 * <li>{@link AssistantMessage} with tool calls → JSON array of tool calls</li>
+	 * <li>{@link ToolResponseMessage} → JSON array of tool responses</li>
+	 * <li>All other types → {@code null}</li>
+	 * </ul>
+	 */
+	@Nullable private String messageDataToJson(Message message) {
+		if (message instanceof AssistantMessage am && am.hasToolCalls()) {
+			return toJson(am.getToolCalls());
+		}
+		if (message instanceof ToolResponseMessage trm) {
+			return toJson(trm.getResponses());
+		}
+		return null;
+	}
+
+	private Message toMessage(MessageType type, @Nullable String content, @Nullable String messageData) {
+		return switch (type) {
+			case USER -> new UserMessage(content != null ? content : "");
+			case SYSTEM -> new SystemMessage(content != null ? content : "");
+			case ASSISTANT -> {
+				if (messageData != null && !messageData.isBlank()) {
+					List<AssistantMessage.ToolCall> toolCalls = parseToolCalls(messageData);
+					yield AssistantMessage.builder().content(content).toolCalls(toolCalls).build();
+				}
+				yield new AssistantMessage(content != null ? content : "");
+			}
+			case TOOL -> {
+				if (messageData != null && !messageData.isBlank()) {
+					List<ToolResponseMessage.ToolResponse> responses = parseToolResponses(messageData);
+					yield ToolResponseMessage.builder().responses(responses).build();
+				}
+				yield ToolResponseMessage.builder().responses(List.of()).build();
+			}
+		};
+	}
+
+	private List<AssistantMessage.ToolCall> parseToolCalls(String json) {
+		try {
+			return this.jsonMapper.readValue(json, new TypeReference<List<AssistantMessage.ToolCall>>() {
+			});
+		}
+		catch (JacksonException ex) {
+			logger.warn("Failed to deserialize tool calls from JSON; returning empty list", ex);
+			return List.of();
+		}
+	}
+
+	private List<ToolResponseMessage.ToolResponse> parseToolResponses(String json) {
+		try {
+			return this.jsonMapper.readValue(json, new TypeReference<List<ToolResponseMessage.ToolResponse>>() {
+			});
+		}
+		catch (JacksonException ex) {
+			logger.warn("Failed to deserialize tool responses from JSON; returning empty list", ex);
+			return List.of();
+		}
+	}
+
+	private Session toSession(Document doc) {
+		Session.Builder builder = Session.builder()
+			.id(doc.get(FIELD_ID).toString())
+			.userId(doc.get(FIELD_USER_ID).toString())
+			.createdAt(toInstant(doc.getDate(FIELD_CREATED_AT)))
+			.metadata(fromJsonMap(doc.get(FIELD_METADATA)));
+		Date expiresAt = doc.getDate(FIELD_EXPIRES_AT);
+		if (expiresAt != null) {
+			builder.expiresAt(expiresAt.toInstant());
+		}
+		return builder.build();
+	}
+
+	private SessionEvent toSessionEvent(Document doc) {
+		MessageType messageType = MessageType.valueOf(doc.getString(FIELD_MESSAGE_TYPE));
+		Message message = toMessage(messageType, doc.getString(FIELD_MESSAGE_CONTENT), doc.getString(FIELD_MESSAGE_DATA));
+
+		// Merge the dedicated synthetic field back into the metadata map so that
+		// SessionEvent.isSynthetic() returns the correct value.
+		Map<String, Object> metadata = new HashMap<>(fromJsonMap(doc.get(FIELD_METADATA)));
+		if (doc.getBoolean(FIELD_SYNTHETIC, false)) {
+			metadata.put(SessionEvent.METADATA_SYNTHETIC, true);
+		}
+
+		return SessionEvent.builder()
+			.id(doc.get(FIELD_ID).toString())
+			.sessionId(doc.getString(FIELD_SESSION_ID))
+			.timestamp(toInstant(doc.getDate(FIELD_TIMESTAMP)))
+			.message(message)
+			.branch(doc.getString(FIELD_BRANCH))
+			.archived(doc.getBoolean(FIELD_ARCHIVED, false))
+			.metadata(metadata)
+			.build();
+	}
+
+	/** Returns a new {@link Builder}. */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	// -------------------------------------------------------------------------
+	// Builder
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Builder for {@link MongoSessionRepository}.
+	 *
+	 * <p>
+	 * Minimum required: a {@link MongoTemplate}. All other fields default to sensible
+	 * values.
+	 */
+	public static final class Builder {
+
+		@Nullable private MongoTemplate mongoTemplate;
+
+		private JsonMapper jsonMapper = JsonMapper.builder().build();
+
+		private Builder() {
+		}
+
+		/** Sets the {@link MongoTemplate}. */
+		public Builder mongoTemplate(MongoTemplate mongoTemplate) {
+			this.mongoTemplate = mongoTemplate;
+			return this;
+		}
+
+		/**
+		 * Overrides the {@link JsonMapper} used for metadata and message-data
+		 * serialization. Defaults to {@code JsonMapper.builder().build()}.
+		 */
+		public Builder jsonMapper(JsonMapper jsonMapper) {
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/** Builds the repository. */
+		public MongoSessionRepository build() {
+			Assert.notNull(this.mongoTemplate, "mongoTemplate must not be null");
+			return new MongoSessionRepository(this.mongoTemplate, this.jsonMapper);
+		}
+
+	}
+
+}

--- a/spring-ai-session-mongodb/src/test/java/org/springframework/ai/session/mongodb/MongoSessionRepositoryTests.java
+++ b/spring-ai-session-mongodb/src/test/java/org/springframework/ai/session/mongodb/MongoSessionRepositoryTests.java
@@ -1,0 +1,536 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.mongodb;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.session.EventFilter;
+import org.springframework.ai.session.Session;
+import org.springframework.ai.session.SessionEvent;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link MongoSessionRepository} backed by a Testcontainers MongoDB instance.
+ *
+ * <p>
+ * Mirrors the contract of {@code JdbcSessionRepositoryTests} and
+ * {@code InMemorySessionRepositoryTests} so all implementations are verified against the
+ * same specification.
+ */
+@Testcontainers
+class MongoSessionRepositoryTests {
+
+	@Container
+	static MongoDBContainer mongo = new MongoDBContainer("mongo:7");
+
+	private MongoTemplate mongoTemplate;
+
+	private MongoSessionRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		this.mongoTemplate = new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongo.getConnectionString()));
+		this.repository = MongoSessionRepository.builder().mongoTemplate(this.mongoTemplate).build();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		this.mongoTemplate.dropCollection("ai_sessions");
+		this.mongoTemplate.dropCollection("ai_session_events");
+	}
+
+	// -------------------------------------------------------------------------
+	// Session lifecycle
+	// -------------------------------------------------------------------------
+
+	@Test
+	void saveAndFindByIdRoundTrip() {
+		Session session = buildSession("user-1");
+		this.repository.save(session);
+
+		Session found = this.repository.findById(session.id());
+		assertThat(found).isNotNull();
+		assertThat(found.id()).isEqualTo(session.id());
+		assertThat(found.userId()).isEqualTo("user-1");
+	}
+
+	@Test
+	void savePreservesExpiresAtAndMetadata() {
+		Instant expiry = Instant.ofEpochMilli(Instant.now().plusSeconds(3600).toEpochMilli());
+		Session session = Session.builder()
+			.id(UUID.randomUUID().toString())
+			.userId("user-meta")
+			.expiresAt(expiry)
+			.metadata(java.util.Map.of("model", "gpt-4o"))
+			.build();
+		this.repository.save(session);
+
+		Session found = this.repository.findById(session.id());
+		assertThat(found).isNotNull();
+		assertThat(found.expiresAt()).isNotNull();
+		assertThat(found.expiresAt().toEpochMilli()).isEqualTo(expiry.toEpochMilli());
+		assertThat(found.metadata()).containsEntry("model", "gpt-4o");
+	}
+
+	@Test
+	void saveUpsertUpdatesMetadataButPreservesEventVersion() {
+		Session session = buildSession("user-upsert");
+		this.repository.save(session);
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("hi")).build());
+		long versionAfterAppend = this.repository.getEventVersion(session.id());
+
+		Session updated = Session.builder()
+			.id(session.id())
+			.userId(session.userId())
+			.metadata(java.util.Map.of("newKey", "newVal"))
+			.build();
+		this.repository.save(updated);
+
+		Session found = this.repository.findById(session.id());
+		assertThat(found).isNotNull();
+		assertThat(found.metadata()).containsEntry("newKey", "newVal");
+		assertThat(this.repository.getEventVersion(session.id())).isEqualTo(versionAfterAppend);
+		assertThat(this.repository.findEvents(session.id(), EventFilter.all())).hasSize(1);
+	}
+
+	@Test
+	void findByIdReturnsNullWhenNotFound() {
+		assertThat(this.repository.findById("no-such-id")).isNull();
+	}
+
+	@Test
+	void findByUserIdReturnsAllSessionsForUser() {
+		this.repository.save(buildSession("alice"));
+		this.repository.save(buildSession("alice"));
+		this.repository.save(buildSession("bob"));
+
+		assertThat(this.repository.findByUserId("alice")).hasSize(2);
+		assertThat(this.repository.findByUserId("bob")).hasSize(1);
+	}
+
+	@Test
+	void deleteRemovesSessionAndCascadesToEvents() {
+		Session session = buildSession("user-del");
+		this.repository.save(session);
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("hi")).build());
+
+		this.repository.delete(session.id());
+
+		assertThat(this.repository.findById(session.id())).isNull();
+		assertThat(this.repository.findEvents(session.id(), EventFilter.all())).isEmpty();
+	}
+
+	@Test
+	void findExpiredSessionIdsReturnsOnlyExpiredOnes() {
+		Session active = buildSession("user-active");
+		Session expired = Session.builder()
+			.id(UUID.randomUUID().toString())
+			.userId("user-expired")
+			.expiresAt(Instant.now().minusSeconds(60))
+			.build();
+		this.repository.save(active);
+		this.repository.save(expired);
+
+		List<String> expiredIds = this.repository.findExpiredSessionIds(Instant.now());
+		assertThat(expiredIds).contains(expired.id());
+		assertThat(expiredIds).doesNotContain(active.id());
+	}
+
+	// -------------------------------------------------------------------------
+	// Event append and retrieval
+	// -------------------------------------------------------------------------
+
+	@Test
+	void appendEventThrowsWhenSessionNotFound() {
+		SessionEvent event = SessionEvent.builder().sessionId("ghost-session").message(new UserMessage("hi")).build();
+		assertThatThrownBy(() -> this.repository.appendEvent(event)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Session not found");
+	}
+
+	@Test
+	void appendedEventsAreReturnedInChronologicalOrder() {
+		Session session = buildSession("user-order");
+		this.repository.save(session);
+
+		for (int i = 1; i <= 4; i++) {
+			Instant ts = Instant.ofEpochSecond(1_700_000_000L + i);
+			this.repository.appendEvent(SessionEvent.builder()
+				.sessionId(session.id())
+				.timestamp(ts)
+				.message(new UserMessage("msg-" + i))
+				.build());
+		}
+
+		List<SessionEvent> events = this.repository.findEvents(session.id(), EventFilter.all());
+		assertThat(events).hasSize(4);
+		assertThat(events.get(0).getMessage().getText()).isEqualTo("msg-1");
+		assertThat(events.get(3).getMessage().getText()).isEqualTo("msg-4");
+	}
+
+	@Test
+	void findEventsLastNReturnsOnlyLastNInChronologicalOrder() {
+		Session session = buildSession("user-lastn");
+		this.repository.save(session);
+
+		for (int i = 1; i <= 5; i++) {
+			Instant ts = Instant.ofEpochSecond(1_700_000_000L + i);
+			this.repository.appendEvent(SessionEvent.builder()
+				.sessionId(session.id())
+				.timestamp(ts)
+				.message(new UserMessage("msg-" + i))
+				.build());
+		}
+
+		List<SessionEvent> last2 = this.repository.findEvents(session.id(), EventFilter.lastN(2));
+		assertThat(last2).hasSize(2);
+		assertThat(last2.get(0).getMessage().getText()).isEqualTo("msg-4");
+		assertThat(last2.get(1).getMessage().getText()).isEqualTo("msg-5");
+	}
+
+	@Test
+	void findEventsRealOnlyExcludesSynthetic() {
+		Session session = buildSession("user-synth");
+		this.repository.save(session);
+
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("real")).build());
+		this.repository.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("shadow prompt"))
+			.metadata(SessionEvent.METADATA_SYNTHETIC, true)
+			.build());
+		this.repository.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new AssistantMessage("summary"))
+			.metadata(SessionEvent.METADATA_SYNTHETIC, true)
+			.build());
+
+		List<SessionEvent> real = this.repository.findEvents(session.id(), EventFilter.realOnly());
+		assertThat(real).hasSize(1);
+		assertThat(real.get(0).getMessage().getText()).isEqualTo("real");
+	}
+
+	@Test
+	void findEventsFilterByMessageType() {
+		Session session = buildSession("user-types");
+		this.repository.save(session);
+
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("q")).build());
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new AssistantMessage("a")).build());
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("q2")).build());
+
+		List<SessionEvent> userOnly = this.repository.findEvents(session.id(),
+				EventFilter.builder().messageTypes(Set.of(MessageType.USER)).build());
+		assertThat(userOnly).hasSize(2);
+		assertThat(userOnly).allMatch(e -> e.getMessageType() == MessageType.USER);
+	}
+
+	@Test
+	void findEventsKeywordSearch() {
+		Session session = buildSession("user-kw");
+		this.repository.save(session);
+
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("hello world")).build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new AssistantMessage("goodbye")).build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("Hello again")).build());
+
+		List<SessionEvent> results = this.repository.findEvents(session.id(), EventFilter.keywordSearch("hello"));
+		assertThat(results).hasSize(2);
+		assertThat(results).allMatch(e -> e.getMessage().getText().toLowerCase().contains("hello"));
+	}
+
+	@Test
+	void findEventsFilterByTimeRange() {
+		Session session = buildSession("user-time");
+		this.repository.save(session);
+
+		Instant t1 = Instant.parse("2025-01-01T10:00:00Z");
+		Instant t2 = Instant.parse("2025-01-01T11:00:00Z");
+		Instant t3 = Instant.parse("2025-01-01T12:00:00Z");
+
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).timestamp(t1).message(new UserMessage("early")).build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).timestamp(t2).message(new UserMessage("mid")).build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).timestamp(t3).message(new UserMessage("late")).build());
+
+		List<SessionEvent> inRange = this.repository.findEvents(session.id(),
+				EventFilter.builder().from(t1).to(t2).build());
+		assertThat(inRange).hasSize(2);
+		assertThat(inRange.get(0).getMessage().getText()).isEqualTo("early");
+		assertThat(inRange.get(1).getMessage().getText()).isEqualTo("mid");
+	}
+
+	@Test
+	void findEventsPagination() {
+		Session session = buildSession("user-page");
+		this.repository.save(session);
+
+		for (int i = 1; i <= 6; i++) {
+			Instant ts = Instant.ofEpochSecond(1_700_000_000L + i);
+			this.repository.appendEvent(SessionEvent.builder()
+				.sessionId(session.id())
+				.timestamp(ts)
+				.message(new UserMessage("msg-" + i))
+				.build());
+		}
+
+		List<SessionEvent> page0 = this.repository.findEvents(session.id(),
+				EventFilter.builder().pageSize(2).page(0).build());
+		List<SessionEvent> page1 = this.repository.findEvents(session.id(),
+				EventFilter.builder().pageSize(2).page(1).build());
+		List<SessionEvent> page2 = this.repository.findEvents(session.id(),
+				EventFilter.builder().pageSize(2).page(2).build());
+
+		assertThat(page0).hasSize(2);
+		assertThat(page1).hasSize(2);
+		assertThat(page2).hasSize(2);
+		assertThat(page0.get(0).getMessage().getText()).isEqualTo("msg-1");
+		assertThat(page1.get(0).getMessage().getText()).isEqualTo("msg-3");
+		assertThat(page2.get(0).getMessage().getText()).isEqualTo("msg-5");
+	}
+
+	@Test
+	void findEventsReturnsEmptyListForNonExistentSession() {
+		assertThat(this.repository.findEvents("ghost", EventFilter.all())).isEmpty();
+	}
+
+	// -------------------------------------------------------------------------
+	// Message type round-trips
+	// -------------------------------------------------------------------------
+
+	@Test
+	void assistantMessageWithToolCallsRoundTrip() {
+		Session session = buildSession("user-tc");
+		this.repository.save(session);
+
+		List<AssistantMessage.ToolCall> toolCalls = List
+			.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"location\":\"Paris\"}"));
+		AssistantMessage msg = AssistantMessage.builder().content("").toolCalls(toolCalls).build();
+
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(msg).build());
+
+		List<SessionEvent> events = this.repository.findEvents(session.id(), EventFilter.all());
+		assertThat(events).hasSize(1);
+		assertThat(events.get(0).hasToolCalls()).isTrue();
+		AssistantMessage retrieved = (AssistantMessage) events.get(0).getMessage();
+		assertThat(retrieved.getToolCalls()).hasSize(1);
+		assertThat(retrieved.getToolCalls().get(0).name()).isEqualTo("get_weather");
+	}
+
+	@Test
+	void toolResponseMessageRoundTrip() {
+		Session session = buildSession("user-tr");
+		this.repository.save(session);
+
+		ToolResponseMessage.ToolResponse response = new ToolResponseMessage.ToolResponse("call-1", "get_weather",
+				"{\"temp\":\"22C\"}");
+		ToolResponseMessage msg = ToolResponseMessage.builder().responses(List.of(response)).build();
+
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(msg).build());
+
+		List<SessionEvent> events = this.repository.findEvents(session.id(), EventFilter.all());
+		assertThat(events).hasSize(1);
+		ToolResponseMessage retrieved = (ToolResponseMessage) events.get(0).getMessage();
+		assertThat(retrieved.getResponses()).hasSize(1);
+		assertThat(retrieved.getResponses().get(0).name()).isEqualTo("get_weather");
+	}
+
+	// -------------------------------------------------------------------------
+	// Versioning and CAS
+	// -------------------------------------------------------------------------
+
+	@Test
+	void getEventVersionStartsAtZeroAndIncrementsOnAppend() {
+		Session session = buildSession("user-ver");
+		this.repository.save(session);
+
+		assertThat(this.repository.getEventVersion(session.id())).isZero();
+
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("a")).build());
+		assertThat(this.repository.getEventVersion(session.id())).isEqualTo(1L);
+
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("b")).build());
+		assertThat(this.repository.getEventVersion(session.id())).isEqualTo(2L);
+	}
+
+	@Test
+	void compactEventsIncrementsVersion() {
+		Session session = buildSession("user-rv");
+		this.repository.save(session);
+		SessionEvent original = SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("original"))
+			.build();
+		this.repository.appendEvent(original);
+
+		long versionBefore = this.repository.getEventVersion(session.id());
+		this.repository.compactEvents(session.id(), List.of(original), List.of(), versionBefore);
+		assertThat(this.repository.getEventVersion(session.id())).isEqualTo(versionBefore + 1);
+	}
+
+	@Test
+	void compactEventsWithCorrectVersionSucceeds() {
+		Session session = buildSession("user-cas-ok");
+		this.repository.save(session);
+		SessionEvent e1 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("msg-1")).build();
+		SessionEvent e2 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("msg-2")).build();
+		this.repository.appendEvent(e1);
+		this.repository.appendEvent(e2);
+
+		long version = this.repository.getEventVersion(session.id());
+		SessionEvent summary = SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("summary"))
+			.build();
+
+		boolean replaced = this.repository.compactEvents(session.id(), List.of(e1), List.of(summary, e2), version);
+
+		assertThat(replaced).isTrue();
+		assertThat(this.repository.getEventVersion(session.id())).isEqualTo(version + 1);
+		// Active view excludes the archived event; ordered by seq (summary precedes window)
+		assertThat(this.repository.findEvents(session.id(), EventFilter.active()))
+			.extracting(e -> e.getMessage().getText())
+			.containsExactly("summary", "msg-2");
+		// Full view retains the archived event ahead of the active window, flagged archived
+		List<SessionEvent> all = this.repository.findEvents(session.id(), EventFilter.all());
+		assertThat(all).extracting(e -> e.getMessage().getText()).containsExactly("msg-1", "summary", "msg-2");
+		assertThat(all.get(0).isArchived()).isTrue();
+		assertThat(all.get(1).isArchived()).isFalse();
+	}
+
+	@Test
+	void compactEventsWithStaleVersionFails() {
+		Session session = buildSession("user-cas-fail");
+		this.repository.save(session);
+		SessionEvent e1 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("msg-1")).build();
+		this.repository.appendEvent(e1);
+
+		long staleVersion = this.repository.getEventVersion(session.id()) - 1;
+		SessionEvent summary = SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("should-not-land"))
+			.build();
+
+		boolean replaced = this.repository.compactEvents(session.id(), List.of(e1), List.of(summary), staleVersion);
+
+		assertThat(replaced).isFalse();
+		List<SessionEvent> all = this.repository.findEvents(session.id(), EventFilter.all());
+		assertThat(all).hasSize(1);
+		assertThat(all.get(0).getMessage().getText()).isEqualTo("msg-1");
+		assertThat(all.get(0).isArchived()).isFalse();
+	}
+
+	@Test
+	void compactEventsPreservesPreviouslyArchivedEvents() {
+		Session session = buildSession("user-archive-multi");
+		this.repository.save(session);
+		SessionEvent e1 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("e1")).build();
+		SessionEvent e2 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("e2")).build();
+		SessionEvent e3 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("e3")).build();
+		this.repository.appendEvent(e1);
+		this.repository.appendEvent(e2);
+		this.repository.appendEvent(e3);
+
+		SessionEvent summary1 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("s1")).build();
+		long v1 = this.repository.getEventVersion(session.id());
+		this.repository.compactEvents(session.id(), List.of(e1), List.of(summary1, e2, e3), v1);
+
+		SessionEvent summary2 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("s2")).build();
+		long v2 = this.repository.getEventVersion(session.id());
+		this.repository.compactEvents(session.id(), List.of(e2), List.of(summary2, e3), v2);
+
+		assertThat(this.repository.findEvents(session.id(), EventFilter.all()))
+			.extracting(e -> e.getMessage().getText())
+			.containsExactly("e1", "e2", "s2", "e3");
+		assertThat(this.repository.findEvents(session.id(), EventFilter.active()))
+			.extracting(e -> e.getMessage().getText())
+			.containsExactly("s2", "e3");
+	}
+
+	// -------------------------------------------------------------------------
+	// Branch filtering
+	// -------------------------------------------------------------------------
+
+	@Test
+	void findEventsWithBranchFilterIsolatesPeerAgents() {
+		Session session = buildSession("user-branch");
+		this.repository.save(session);
+
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("root")).branch(null).build());
+		this.repository.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("by orchestrator"))
+			.branch("orch")
+			.build());
+		this.repository.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("by researcher"))
+			.branch("orch.researcher")
+			.build());
+		this.repository.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("by writer"))
+			.branch("orch.writer")
+			.build());
+
+		List<SessionEvent> forResearcher = this.repository.findEvents(session.id(),
+				EventFilter.forBranch("orch.researcher"));
+
+		assertThat(forResearcher).hasSize(3);
+		assertThat(forResearcher).noneMatch(e -> "by writer".equals(e.getMessage().getText()));
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private Session buildSession(String userId) {
+		return Session.builder().id(UUID.randomUUID().toString()).userId(userId).build();
+	}
+
+}


### PR DESCRIPTION
Add Spring Data MongoDB-backed SessionRepository with the same three-tier module structure as the JDBC implementation: core repository, auto-configuration, and Spring Boot starter.

The MongoSessionRepository uses two collections (ai_sessions and ai_session_events) with atomic $inc and findAndModify operations for thread-safe optimistic concurrency control (CAS) via eventVersion. Event ordering is maintained by a per-session eventSeq counter that is atomically incremented on each append, mirroring the JDBC seq column.

