### PR TITLE
Optimize JdbcSessionRepository#compactEvents for large sessions

### DIFF
--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
@@ -139,14 +139,17 @@ public final class JdbcSessionRepository implements SessionRepository {
 	private static final String COUNT_SESSION =
 		"SELECT COUNT(*) FROM AI_SESSION WHERE id = ?";
 
+	// Used only in appendEvent or full-session teardown (not in compactEvents anymore)
 	private static final String DELETE_EVENTS =
 		"DELETE FROM AI_SESSION_EVENT WHERE session_id = ?";
 
-	private static final String SELECT_ARCHIVED_EVENTS =
-		"SELECT e.id, e.session_id, e.timestamp, e.message_type, e.message_content,"
-		+ "       e.message_data, e.synthetic, e.archived, e.branch, e.metadata"
-		+ " FROM AI_SESSION_EVENT e"
-		+ " WHERE e.session_id = ? AND e.archived = ? ORDER BY e.seq ASC";
+	// Marks events as archived without rewriting existing rows.
+	private static final String ARCHIVE_EVENT_BY_ID =
+		"UPDATE AI_SESSION_EVENT SET archived = true WHERE id = ?";
+
+	// Removes the active window before inserting the retained events produced by compaction.
+	private static final String DELETE_ACTIVE_EVENTS =
+		"DELETE FROM AI_SESSION_EVENT WHERE session_id = ? AND archived = false";
 
 	private static final String SELECT_EVENTS_BASE =
 		"SELECT e.id, e.session_id, e.timestamp, e.message_type, e.message_content,"
@@ -239,16 +242,22 @@ public final class JdbcSessionRepository implements SessionRepository {
 			if (updated == 0) {
 				return false;
 			}
-			// Read the previously-archived events (oldest prefix) so they survive the
-			// delete-and-reinsert. The whole log is rebuilt in order so the auto-assigned
-			// `seq` reflects the logical conversation order: previously-archived events,
-			// then newly-archived events, then the new active window (summary + recent).
-			List<SessionEvent> previouslyArchived = this.jdbcTemplate.query(SELECT_ARCHIVED_EVENTS,
-					new SessionEventRowMapper(), sessionId, true);
-			this.jdbcTemplate.update(DELETE_EVENTS, sessionId);
-			previouslyArchived.forEach(this::insertEvent);
-			archivedEvents.forEach(e -> insertEvent(e.asArchived()));
-			retainedEvents.forEach(this::insertEvent);
+			// Archive newly compacted events in place. This avoids deleting and
+			// reinserting the complete session history while preserving the
+			// logical event ordering defined by the seq column.
+			if (!archivedEvents.isEmpty()) {
+				this.jdbcTemplate.batchUpdate(ARCHIVE_EVENT_BY_ID, archivedEvents, archivedEvents.size(),
+						(ps, event) -> ps.setString(1, event.getId()));
+			}
+
+			// Replace the active window with the retained events. Archived events
+			// remain untouched and preserve their original ordering.
+			this.jdbcTemplate.update(DELETE_ACTIVE_EVENTS, sessionId);
+
+			if (!retainedEvents.isEmpty()) {
+				batchInsertEvents(retainedEvents);
+			}
+
 			return true;
 		});
 		return Boolean.TRUE.equals(success);
@@ -339,6 +348,26 @@ public final class JdbcSessionRepository implements SessionRepository {
 		this.jdbcTemplate.update(INSERT_EVENT, event.getId(), event.getSessionId(), toTimestamp(event.getTimestamp()),
 				msg.getMessageType().name(), msg.getText(), messageDataToJson(msg), event.isSynthetic(),
 				event.isArchived(), event.getBranch(), toJson(event.getMetadata()));
+	}
+
+	/**
+	 * Inserts the supplied events using a JDBC batch operation.
+	 */
+	private void batchInsertEvents(List<SessionEvent> events) {
+		this.jdbcTemplate.batchUpdate(INSERT_EVENT, events, events.size(), (ps, event) -> {
+			Message msg = event.getMessage();
+			ps.setString(1, event.getId());
+			ps.setString(2, event.getSessionId());
+			Timestamp ts = toTimestamp(event.getTimestamp());
+			ps.setTimestamp(3, ts);
+			ps.setString(4, msg.getMessageType().name());
+			ps.setString(5, msg.getText());
+			ps.setString(6, messageDataToJson(msg));
+			ps.setBoolean(7, event.isSynthetic());
+			ps.setBoolean(8, event.isArchived());
+			ps.setString(9, event.getBranch());
+			ps.setString(10, toJson(event.getMetadata()));
+		});
 	}
 
 	private void requireSessionExists(String sessionId) {

--- a/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
+++ b/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
@@ -560,6 +560,83 @@ class JdbcSessionRepositoryTests {
 		assertThat(forResearcher).noneMatch(e -> "by writer".equals(e.getMessage().getText()));
 	}
 
+	@Test
+	void multipleCompactionsPreserveOrderAndGC() {
+		Session session = buildSession("user-multi-compact");
+		this.repository.save(session);
+
+		// 1. Initial messages
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("m1")).build());
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("m2")).build());
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("m3")).build());
+
+		List<SessionEvent> initial = this.repository.findEvents(session.id(), EventFilter.all());
+		
+		// First compaction: archive m1, m2. retain summary1, m3.
+		SessionEvent summary1 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("summary1")).build();
+		this.repository.compactEvents(session.id(), 
+			List.of(initial.get(0), initial.get(1)), // m1, m2
+			List.of(summary1, initial.get(2)),       // summary1, m3
+			this.repository.getEventVersion(session.id()));
+
+		// 2. Append more messages
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("m4")).build());
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("m5")).build());
+
+		List<SessionEvent> afterFirst = this.repository.findEvents(session.id(), EventFilter.all());
+		// Expected: m1(archived), m2(archived), summary1, m3, m4, m5
+		assertThat(afterFirst).hasSize(6);
+		assertThat(afterFirst.get(2).getMessage().getText()).isEqualTo("summary1");
+
+		// Second compaction: archive summary1, m3, m4. retain summary2, m5.
+		// Note that summary1 was an active event. It will be archived now.
+		SessionEvent summary2 = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("summary2")).build();
+		this.repository.compactEvents(session.id(), 
+			List.of(afterFirst.get(2), afterFirst.get(3), afterFirst.get(4)), // summary1, m3, m4
+			List.of(summary2, afterFirst.get(5)),                             // summary2, m5
+			this.repository.getEventVersion(session.id()));
+
+		// 3. Append another
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("m6")).build());
+
+		List<SessionEvent> finalEvents = this.repository.findEvents(session.id(), EventFilter.all());
+		
+		// Expected: m1, m2, summary1, m3, m4 (all archived), then summary2, m5, m6 (active)
+		assertThat(finalEvents).hasSize(8);
+		assertThat(finalEvents).extracting(e -> e.getMessage().getText())
+			.containsExactly("m1", "m2", "summary1", "m3", "m4", "summary2", "m5", "m6");
+		
+		assertThat(finalEvents).extracting(SessionEvent::isArchived)
+			.containsExactly(true, true, true, true, true, false, false, false);
+	}
+
+	@Test
+	void compactEventsGarbageCollectsDroppedSummaries() {
+		Session session = buildSession("user-gc");
+		this.repository.save(session);
+
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("m1")).build());
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("summary-stale")).build());
+		this.repository.appendEvent(SessionEvent.builder().sessionId(session.id()).message(new UserMessage("m2")).build());
+
+		List<SessionEvent> initial = this.repository.findEvents(session.id(), EventFilter.all());
+		
+		// Compact: archive m1. retain summary-new, m2.
+		// We explicitly do NOT include summary-stale in either list. It should be garbage collected.
+		SessionEvent summaryNew = SessionEvent.builder().sessionId(session.id()).message(new UserMessage("summary-new")).build();
+		this.repository.compactEvents(session.id(), 
+			List.of(initial.get(0)), // m1
+			List.of(summaryNew, initial.get(2)), // summary-new, m2
+			this.repository.getEventVersion(session.id()));
+
+		List<SessionEvent> finalEvents = this.repository.findEvents(session.id(), EventFilter.all());
+		
+		// Expected: m1, summary-new, m2
+		assertThat(finalEvents).hasSize(3);
+		assertThat(finalEvents).extracting(e -> e.getMessage().getText())
+			.containsExactly("m1", "summary-new", "m2");
+	}
+
 	// -------------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Compaction was reloading, deleting, and reinserting every event for a session on each run, even the ones already archived. That made compaction cost grow with the full session history instead of just the active window, which got slow on long-running conversations.

This change only touches the active range being compacted `archived events` are left untouched on disk and never re-read or re-written. Added tests to confirm archived events stay unchanged across repeated compactions. No changes to the SessionRepository contract, just an internal fix.

Fixes #28