### PR TITLE
Add runtime branch isolation to SessionMemoryAdvisor

### DIFF
--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
@@ -142,10 +142,10 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 	@Override
 	public ChatClientRequest before(ChatClientRequest request, AdvisorChain advisorChain) {
 
-		// Resolve the session ID — must be present in the request context.
+		// 0. Resolve the session ID — must be present in the request context.
 		String sessionId = getSessionId(request.context());
 
-		// Find or create the session. The Session object is cached in the request
+		// 1. Find or create the session. The Session object is cached in the request
 		// context so that after() can reuse it and skip a redundant findById()
 		// repository round-trip when compaction is configured.
 		Session session = this.sessionService.findById(sessionId);
@@ -165,8 +165,11 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 			}
 		}
 
-		// Retrieve history applying the configured filter (default: all events)
+		// 2. Retrieve history applying the configured filter (default: all events)
 
+		// If the request context contains an EventFilter, merge it with the advisor's
+		// configured filter so that request-level parameters override the advisor
+		// defaults
 		EventFilter eventFilter = getEventFilter(request.context());
 
 		// Always exclude archived events from the active context window — they were
@@ -180,7 +183,7 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 		List<Message> combined = new ArrayList<>(history);
 		combined.addAll(request.prompt().getInstructions());
 
-		// Ensure all system messages appear first (preserving their relative order).
+		// 3. Ensure all system messages appear first (preserving their relative order).
 		// A single pass collects every SystemMessage, removes them in place, then
 		// prepends them as a block — so a system message buried in history and a
 		// second one on the current request both end up at the front rather than
@@ -191,9 +194,9 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 			combined.addAll(0, systemMessages);
 		}
 
-		// Append the current user or tool-response message to the session, subject to the configured
-		// message filter. Skipping only affects persistence — the outgoing prompt is untouched.
-		// Write it to the resolved branch (null = root) so it is properly isolated.
+		// 4. Append the current user message to the session, subject to the configured
+		// message filter. Skipping only affects persistence — the outgoing prompt is
+		// untouched.
 		Message userMessage = request.prompt().getLastUserOrToolResponseMessage();
 		if (userMessage != null && shouldPersist(userMessage, sessionId)) {
 			SessionEvent event = SessionEvent.builder()
@@ -211,10 +214,9 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 	public ChatClientResponse after(ChatClientResponse response, AdvisorChain advisorChain) {
 		String sessionId = getSessionId(response.context());
 
-		// Append the assistant message(s) produced by the model, subject to the
+		// 1. Append the assistant message(s) produced by the model, subject to the
 		// configured message filter. By default excludes messages that carry no
 		// content — blank text, no tool calls, and no media.
-		// Writes to the resolved branch.
 		if (response.chatResponse() != null) {
 			Map<String, @Nullable Object> context = response.context();
 			String branch = getEventFilter(context).branch();
@@ -233,7 +235,7 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 				});
 		}
 
-		// Compact synchronously if configured — the full turn (user + assistant) is
+		// 2. Compact synchronously if configured — the full turn (user + assistant) is
 		// already written at this point so there is no race.
 		if (this.compactionTrigger != null && this.compactionStrategy != null) {
 			this.sessionService.compact(sessionId, this.compactionTrigger, this.compactionStrategy);

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
@@ -138,10 +138,10 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 	@Override
 	public ChatClientRequest before(ChatClientRequest request, AdvisorChain advisorChain) {
 
-		// 0. Resolve the session ID — must be present in the request context.
+		// Resolve the session ID — must be present in the request context.
 		String sessionId = getSessionId(request.context());
 
-		// 1. Find or create the session. The Session object is cached in the request
+		// Find or create the session. The Session object is cached in the request
 		// context so that after() can reuse it and skip a redundant findById()
 		// repository round-trip when compaction is configured.
 		Session session = this.sessionService.findById(sessionId);
@@ -161,31 +161,22 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 			}
 		}
 
-		// 2. Retrieve history applying the configured filter (default: all events)
+		// Retrieve history applying the configured filter (default: all events)
 
-		// If the request context contains an EventFilter, merge it with the advisor's
-		// configured filter so that request-level parameters override the advisor
-		// defaults
-		EventFilter eventFilter = this.eventFilter;
-		if (request.context().containsKey(EVENT_FILTER_CONTEXT_KEY)) {
-			EventFilter requestEventFilter = (EventFilter) request.context().get(EVENT_FILTER_CONTEXT_KEY);
-			if (requestEventFilter != null) {
-				eventFilter = this.eventFilter.merge(requestEventFilter);
-			}
-		}
+		EventFilter eventFilter = getEventFilter(request.context());
 
 		// Always exclude archived events from the active context window — they were
 		// compacted out and live on only for Recall Storage search. Merging forces the
 		// flag on regardless of the configured or per-request filter.
-		eventFilter = eventFilter.merge(EventFilter.active());
+		EventFilter fetchFilter = eventFilter.merge(EventFilter.active());
 
-		List<SessionEvent> events = this.sessionService.getEvents(sessionId, eventFilter);
+		List<SessionEvent> events = this.sessionService.getEvents(sessionId, fetchFilter);
 		List<Message> history = events.stream().map(SessionEvent::getMessage).toList();
 
 		List<Message> combined = new ArrayList<>(history);
 		combined.addAll(request.prompt().getInstructions());
 
-		// 3. Ensure all system messages appear first (preserving their relative order).
+		// Ensure all system messages appear first (preserving their relative order).
 		// A single pass collects every SystemMessage, removes them in place, then
 		// prepends them as a block — so a system message buried in history and a
 		// second one on the current request both end up at the front rather than
@@ -196,10 +187,16 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 			combined.addAll(0, systemMessages);
 		}
 
-		// 4. Append the current user message to the session
+		// Append the current user or tool-response message to the session
+		// Write it to the resolved branch (null = root) so it is properly isolated
 		Message userMessage = request.prompt().getLastUserOrToolResponseMessage();
-		if (userMessage != null) {
-			this.sessionService.appendMessage(sessionId, userMessage);
+		if (userMessage != null && shouldPersist(userMessage, sessionId)) {
+			SessionEvent event = SessionEvent.builder()
+				.sessionId(sessionId)
+				.branch(eventFilter.branch())
+				.message(userMessage)
+				.build();
+			this.sessionService.appendEvent(event);
 		}
 
 		return request.mutate().prompt(request.prompt().mutate().messages(combined).build()).build();
@@ -209,18 +206,27 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 	public ChatClientResponse after(ChatClientResponse response, AdvisorChain advisorChain) {
 		String sessionId = getSessionId(response.context());
 
-		// 1. Append the assistant message(s) produced by the model. Excludes messages
-		// that carry no content — blank text, no tool calls, and no media.
+		// Append the assistant message(s) produced by the model. Excludes messages
+		// that do not pass the configured message filter. Writes to the resolved branch.
 		if (response.chatResponse() != null) {
+			Map<String, @Nullable Object> context = response.context();
+			String branch = getEventFilter(context).branch();
 			response.chatResponse()
 				.getResults()
 				.stream()
 				.map(g -> (Message) g.getOutput())
 				.filter(msg -> shouldPersist(msg, sessionId))
-				.forEach(msg -> this.sessionService.appendMessage(sessionId, msg));
+				.forEach(msg -> {
+					SessionEvent event = SessionEvent.builder()
+						.sessionId(sessionId)
+						.branch(branch)
+						.message(msg)
+						.build();
+					this.sessionService.appendEvent(event);
+				});
 		}
 
-		// 2. Compact synchronously if configured — the full turn (user + assistant) is
+		// Compact synchronously if configured — the full turn (user + assistant) is
 		// already written at this point so there is no race.
 		if (this.compactionTrigger != null && this.compactionStrategy != null) {
 			this.sessionService.compact(sessionId, this.compactionTrigger, this.compactionStrategy);
@@ -251,6 +257,15 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 		throw new IllegalStateException(
 				"No session ID found in advisor context. " + "Set SESSION_ID_CONTEXT_KEY on every request: "
 						+ ".advisors(a -> a.param(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, sessionId))");
+	}
+
+	private EventFilter getEventFilter(Map<String, @Nullable Object> context) {
+		EventFilter filter = this.eventFilter;
+		EventFilter requestFilter = (EventFilter) context.get(EVENT_FILTER_CONTEXT_KEY);
+		if (requestFilter != null) {
+			filter = filter.merge(requestFilter);
+		}
+		return filter;
 	}
 
 	private String getUserId(Map<String, @Nullable Object> context) {

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
@@ -335,6 +335,115 @@ class SessionMemoryAdvisorIT {
 		assertThat(texts).contains("only message");
 	}
 
+	@Test
+	void shouldUseRuntimeBranchFilterWhenLoadingHistory() {
+		// Base root messages
+		this.sessionService.appendEvent(SessionEvent.builder().sessionId(this.sessionId).message(new UserMessage("root")).build());
+		// Sibling branch message
+		this.sessionService.appendEvent(SessionEvent.builder().sessionId(this.sessionId).branch("research").message(new AssistantMessage("research output")).build());
+		// Target branch message
+		this.sessionService.appendEvent(SessionEvent.builder().sessionId(this.sessionId).branch("planner").message(new AssistantMessage("planner output")).build());
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("follow-up")));
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId,
+					SessionMemoryAdvisor.EVENT_FILTER_CONTEXT_KEY, EventFilter.forBranch("planner")))
+			.build();
+
+		ChatClientRequest modified = this.advisor.before(request, mock(AdvisorChain.class));
+
+		List<String> texts = modified.prompt().getInstructions().stream().map(Message::getText).toList();
+		// Should load root + planner, exclude research
+		assertThat(texts).contains("root", "planner output");
+		assertThat(texts).doesNotContain("research output");
+	}
+
+	@Test
+	void shouldAppendMessagesToResolvedBranch() {
+		Prompt prompt = new Prompt(List.of(new UserMessage("planner input")));
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId,
+					SessionMemoryAdvisor.EVENT_FILTER_CONTEXT_KEY, EventFilter.forBranch("planner")))
+			.build();
+
+		this.advisor.before(request, mock(AdvisorChain.class));
+
+		ChatResponse chatResponse = ChatResponse.builder().generations(List.of(new Generation(new AssistantMessage("planner assistant output")))).build();
+		ChatClientResponse response = ChatClientResponse.builder()
+			.chatResponse(chatResponse)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId,
+					SessionMemoryAdvisor.EVENT_FILTER_CONTEXT_KEY, EventFilter.forBranch("planner")))
+			.build();
+			
+		this.advisor.after(response, mock(AdvisorChain.class));
+
+		List<SessionEvent> events = this.sessionService.getEvents(this.sessionId, EventFilter.all());
+		
+		assertThat(events).hasSize(2);
+		assertThat(events.get(0).getBranch()).isEqualTo("planner");
+		assertThat(events.get(0).getMessage().getText()).isEqualTo("planner input");
+		
+		assertThat(events.get(1).getBranch()).isEqualTo("planner");
+		assertThat(events.get(1).getMessage().getText()).isEqualTo("planner assistant output");
+	}
+
+	@Test
+	void shouldPreserveReadWriteBranchSymmetry() {
+		// Populate some initial root history
+		this.sessionService.appendEvent(SessionEvent.builder().sessionId(this.sessionId).message(new UserMessage("root question")).build());
+		this.sessionService.appendEvent(SessionEvent.builder().sessionId(this.sessionId).message(new AssistantMessage("root answer")).build());
+
+		// Single Request turn targeting "planner" branch
+		Map<String, Object> ctx = Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId,
+				SessionMemoryAdvisor.EVENT_FILTER_CONTEXT_KEY, EventFilter.forBranch("planner"));
+		
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(List.of(new UserMessage("planner turn")))).context(ctx).build();
+		AdvisorChain chain = mock(AdvisorChain.class);
+		
+		ChatClientRequest modified = this.advisor.before(request, chain);
+		List<String> texts = modified.prompt().getInstructions().stream().map(Message::getText).toList();
+		assertThat(texts).contains("root question", "root answer", "planner turn");
+
+		ChatClientResponse response = ChatClientResponse.builder()
+			.chatResponse(ChatResponse.builder().generations(List.of(new Generation(new AssistantMessage("planner response")))).build())
+			.context(ctx)
+			.build();
+			
+		this.advisor.after(response, chain);
+
+		// Verify the session log has root and planner branch messages cleanly separated
+		List<SessionEvent> allEvents = this.sessionService.getEvents(this.sessionId, EventFilter.all());
+		assertThat(allEvents).hasSize(4);
+		assertThat(allEvents).extracting(SessionEvent::getBranch)
+			.containsExactly(null, null, "planner", "planner");
+	}
+
+	@Test
+	void shouldFallbackToConfiguredEventFilter() {
+		// Setup an advisor that has a default branch configured via builder
+		SessionMemoryAdvisor branchAdvisor = SessionMemoryAdvisor.builder(this.sessionService)
+			.eventFilter(EventFilter.forBranch("research"))
+			.build();
+			
+		this.sessionService.appendEvent(SessionEvent.builder().sessionId(this.sessionId).branch("research").message(new UserMessage("research question")).build());
+		this.sessionService.appendEvent(SessionEvent.builder().sessionId(this.sessionId).branch("other").message(new UserMessage("other question")).build());
+
+		// Request without any EVENT_FILTER_CONTEXT_KEY
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(new Prompt(List.of(new UserMessage("follow up"))))
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId))
+			.build();
+			
+		ChatClientRequest modified = branchAdvisor.before(request, mock(AdvisorChain.class));
+		
+		// It should use the default "research" branch filter
+		List<String> texts = modified.prompt().getInstructions().stream().map(Message::getText).toList();
+		assertThat(texts).contains("research question", "follow up");
+		assertThat(texts).doesNotContain("other question");
+	}
+
 	// --- Empty assistant message filtering ---
 
 	@Test


### PR DESCRIPTION
Fixes #15

SessionMemoryAdvisor only supported branch targeting at bean creation via the builder, making per-request branch isolation impossible for multi-agent/multi-tenant use cases.

This PR resolves the EventFilter dynamically per request via EVENT_FILTER_CONTEXT_KEY, falling back to the advisor's configured default when no override is given.

Changes:
- getEventFilter(context) merges advisor default + request override.
- before()/after() write user/assistant messages to the resolved branch (via SessionEvent) instead of always writing to root.
- Added 4 integration tests: runtime override, branch writes, read/write symmetry, default fallback.

Note: Compaction (TurnCountTrigger, SessionService.compact()) is untouched here — will be tracked separately if confirmed branch-unaware.