### PR TITLE
Route branch-scoped compaction through repository and service layers

### DIFF
--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
@@ -147,6 +147,15 @@ public final class JdbcSessionRepository implements SessionRepository {
 	private static final String DELETE_ACTIVE_EVENTS =
 		"DELETE FROM AI_SESSION_EVENT WHERE session_id = ? AND archived = false";
 
+	// Scoped variant: only removes active events owned by scopeBranch (itself or a
+	// dot-prefix sub-branch), leaving root events and sibling branches untouched. The LIKE
+	// pattern is built in Java and bound as a parameter, so this is dialect-independent —
+	// unlike the ancestor-inclusive branch-visibility fragment used by findEvents(), no
+	// dialect override is needed here.
+	private static final String DELETE_ACTIVE_EVENTS_FOR_BRANCH =
+		"DELETE FROM AI_SESSION_EVENT WHERE session_id = ? AND archived = false"
+		+ " AND (branch = ? OR branch LIKE ?)";
+
 	private static final String SELECT_EVENTS_BASE =
 		"SELECT e.id, e.session_id, e.timestamp, e.message_type, e.message_content,"
 		+ "       e.message_data, e.synthetic, e.archived, e.branch, e.metadata"
@@ -225,7 +234,7 @@ public final class JdbcSessionRepository implements SessionRepository {
 	}
 
 	@Override
-	public boolean compactEvents(String sessionId, List<SessionEvent> archivedEvents,
+	public boolean compactEvents(String sessionId, @Nullable String scopeBranch, List<SessionEvent> archivedEvents,
 			List<SessionEvent> retainedEvents, long expectedVersion) {
 		Assert.hasText(sessionId, "sessionId must not be null or empty");
 		Assert.notNull(archivedEvents, "archivedEvents must not be null");
@@ -246,9 +255,17 @@ public final class JdbcSessionRepository implements SessionRepository {
 						(ps, event) -> ps.setString(1, event.getId()));
 			}
 
-			// Replace the active window with the retained events. Archived events
-			// remain untouched and preserve their original ordering.
-			this.jdbcTemplate.update(DELETE_ACTIVE_EVENTS, sessionId);
+			// Replace the active window with the retained events. Archived events remain
+			// untouched. For whole-session scope (scopeBranch == null) every active event
+			// is eligible for replacement, exactly as before. For branch scope, only active
+			// events owned by scopeBranch (itself or a dot-prefix sub-branch) are removed —
+			// root events and sibling branches are left in place.
+			if (scopeBranch == null) {
+				this.jdbcTemplate.update(DELETE_ACTIVE_EVENTS, sessionId);
+			}
+			else {
+				this.jdbcTemplate.update(DELETE_ACTIVE_EVENTS_FOR_BRANCH, sessionId, scopeBranch, scopeBranch + ".%");
+			}
 
 			if (!retainedEvents.isEmpty()) {
 				batchInsertEvents(retainedEvents);

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/DefaultSessionService.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/DefaultSessionService.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.session.compaction.CompactionRequest;
 import org.springframework.ai.session.compaction.CompactionResult;
+import org.springframework.ai.session.compaction.CompactionScope;
 import org.springframework.ai.session.compaction.CompactionStrategy;
 import org.springframework.ai.session.compaction.CompactionTrigger;
 import org.springframework.util.Assert;
@@ -112,8 +113,9 @@ public class DefaultSessionService implements SessionService {
 	}
 
 	@Override
-	public CompactionResult compact(String sessionId, CompactionTrigger trigger, CompactionStrategy strategy) {
+	public CompactionResult compact(String sessionId, CompactionScope scope, CompactionTrigger trigger, CompactionStrategy strategy) {
 		Assert.hasText(sessionId, "sessionId must not be null or empty");
+		Assert.notNull(scope, "scope must not be null");
 		Assert.notNull(trigger, "trigger must not be null");
 		Assert.notNull(strategy, "strategy must not be null");
 
@@ -126,15 +128,26 @@ public class DefaultSessionService implements SessionService {
 		// guaranteed to be ≤ the version of the events we subsequently read. If another
 		// writer (append or compaction) mutates the log between our read and our write,
 		// the CAS will detect the version mismatch and return false — we skip silently,
-		// as the concurrent writer already handled the session.
+		// as the concurrent writer already handled the session. The version remains
+		// session-level (not per-branch) even for branch scope: a concurrent write to any
+		// branch causes a branch-scoped compaction to no-op and retry next turn, which is
+		// conservative but never loses or corrupts data. Per-branch version vectors are a
+		// possible future optimization, not required for correctness.
 		long version = this.sessionRepository.getEventVersion(session.id());
 
 		// Operate on the active context window only — already-archived events are
 		// retained for Recall Storage and must not be re-processed (or re-summarized) by
-		// compaction.
-		List<SessionEvent> events = this.sessionRepository.findEvents(session.id(), EventFilter.active());
+		// compaction. For branch scope, further restrict to events owned by that branch
+		// (root events and sibling branches are excluded so a branch-scoped compaction
+		// never inspects, let alone archives, events it does not own). v1: filtered in
+		// Java after loading the full active window; a dedicated owned-only repository
+		// query would be more index-efficient for sessions with many branches — a
+		// follow-up, not required for correctness.
+		List<SessionEvent> activeEvents = this.sessionRepository.findEvents(session.id(), EventFilter.active());
+		List<SessionEvent> events = scope.isSession() ? activeEvents
+				: activeEvents.stream().filter(scope::owns).toList();
 
-		CompactionRequest request = CompactionRequest.of(session, events);
+		CompactionRequest request = CompactionRequest.of(session, events, scope);
 
 		if (!trigger.shouldCompact(request)) {
 			return new CompactionResult(events, List.of(), 0);
@@ -143,8 +156,8 @@ public class DefaultSessionService implements SessionService {
 		CompactionResult result = strategy.compact(request);
 
 		if (!result.archivedEvents().isEmpty()) {
-			boolean replaced = this.sessionRepository.compactEvents(session.id(), result.archivedEvents(),
-					result.compactedEvents(), version);
+			boolean replaced = this.sessionRepository.compactEvents(session.id(), scope.branch(),
+					result.archivedEvents(), result.compactedEvents(), version);
 			if (!replaced) {
 				// CAS rejected — a concurrent writer already mutated the log; skip
 				// silently.

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/InMemorySessionRepository.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/InMemorySessionRepository.java
@@ -113,7 +113,7 @@ public final class InMemorySessionRepository implements SessionRepository {
 	}
 
 	@Override
-	public boolean compactEvents(String sessionId, List<SessionEvent> archivedEvents,
+	public boolean compactEvents(String sessionId, @Nullable String scopeBranch, List<SessionEvent> archivedEvents,
 			List<SessionEvent> retainedEvents, long expectedVersion) {
 		Assert.hasText(sessionId, "sessionId must not be null or empty");
 		Assert.notNull(archivedEvents, "archivedEvents must not be null");
@@ -127,16 +127,35 @@ public final class InMemorySessionRepository implements SessionRepository {
 				return existing;
 			}
 			success[0] = true;
-			// Preserve previously-archived events (always the oldest prefix), then the
-			// newly-archived events (marked archived), then the new active window. Any other
-			// previously-active event (e.g. a superseded synthetic summary) is dropped.
+			// Preserve previously-archived events (always the oldest prefix), then any
+			// currently-active event NOT owned by scopeBranch (root events and sibling
+			// branches — untouched by a branch-scoped compaction; for whole-session scope
+			// (scopeBranch == null) every event is owned, so nothing survives this step),
+			// then the newly-archived events (marked archived), then the new active window
+			// for the owned scope.
 			List<SessionEvent> newEvents = new ArrayList<>();
 			existing.events().stream().filter(SessionEvent::isArchived).forEach(newEvents::add);
+			existing.events()
+				.stream()
+				.filter(e -> !e.isArchived() && !isOwnedBy(e.getBranch(), scopeBranch))
+				.forEach(newEvents::add);
 			archivedEvents.forEach(e -> newEvents.add(e.asArchived()));
 			newEvents.addAll(retainedEvents);
 			return existing.withEvents(List.copyOf(newEvents));
 		});
 		return success[0];
+	}
+
+	/**
+	 * Returns {@code true} if {@code eventBranch} is owned by {@code scopeBranch}:
+	 * {@code scopeBranch == null} (whole-session scope) owns every event; otherwise the
+	 * event's branch must equal {@code scopeBranch} or be a dot-prefix descendant of it.
+	 */
+	private static boolean isOwnedBy(@Nullable String eventBranch, @Nullable String scopeBranch) {
+		if (scopeBranch == null) {
+			return true;
+		}
+		return eventBranch != null && (eventBranch.equals(scopeBranch) || eventBranch.startsWith(scopeBranch + "."));
 	}
 
 	@Override

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/SessionRepository.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/SessionRepository.java
@@ -98,8 +98,37 @@ public interface SessionRepository {
 	 * @return {@code true} when the swap succeeded, {@code false} on a version mismatch
 	 * @throws IllegalArgumentException if the session does not exist
 	 */
-	boolean compactEvents(String sessionId, List<SessionEvent> archivedEvents, List<SessionEvent> retainedEvents,
-			long expectedVersion);
+	default boolean compactEvents(String sessionId, List<SessionEvent> archivedEvents, List<SessionEvent> retainedEvents, long expectedVersion) {
+		return compactEvents(sessionId, null, archivedEvents, retainedEvents, expectedVersion);
+	}
+
+	/**
+	 * Scoped variant of {@link #compactEvents(String, List, List, long)}.
+	 * <p>
+	 * {@code scopeBranch == null} reproduces the whole-session swap exactly: every active
+	 * event in the session is eligible to be replaced by {@code retainedEvents} (this is
+	 * what the 4-arg overload delegates to).
+	 * <p>
+	 * {@code scopeBranch != null} restricts the swap to events <em>owned</em> by that
+	 * branch — the branch itself and its dot-prefix sub-branches (e.g. scope
+	 * {@code "planner"} owns {@code "planner"} and {@code "planner.sub"}). Root events and
+	 * sibling branches are left untouched: only the active events owned by
+	 * {@code scopeBranch} are eligible for replacement by {@code retainedEvents}, and
+	 * {@code retainedEvents} must itself only contain events owned by {@code scopeBranch}
+	 * (a compaction pass must never write outside the scope it was given).
+	 * @param sessionId the session whose log is being compacted
+	 * @param scopeBranch the branch this compaction pass owns, or {@code null} for
+	 * whole-session scope
+	 * @param archivedEvents events to mark archived (must already exist in the log, and be
+	 * owned by {@code scopeBranch})
+	 * @param retainedEvents the new active event set for the owned scope, in chronological
+	 * order
+	 * @param expectedVersion the event-log version the caller observed
+	 * @return {@code true} when the swap succeeded, {@code false} on a version mismatch
+	 * @throws IllegalArgumentException if the session does not exist
+	 */
+	boolean compactEvents(String sessionId, @Nullable String scopeBranch, List<SessionEvent> archivedEvents,
+			List<SessionEvent> retainedEvents, long expectedVersion);
 
 	/**
 	 * Returns the current event-log version for the given session. The version is

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/SessionService.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/SessionService.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.session.compaction.CompactionResult;
+import org.springframework.ai.session.compaction.CompactionScope;
 import org.springframework.ai.session.compaction.CompactionStrategy;
 import org.springframework.ai.session.compaction.CompactionTrigger;
 
@@ -106,6 +107,22 @@ public interface SessionService {
 	 * {@link org.springframework.ai.session.compaction.CompactionResult#archivedEvents()}
 	 * is empty when the trigger did not fire or when the strategy archived nothing
 	 */
-	CompactionResult compact(String sessionId, CompactionTrigger trigger, CompactionStrategy strategy);
+	default CompactionResult compact(String sessionId, CompactionTrigger trigger, CompactionStrategy strategy) {
+		return compact(sessionId, CompactionScope.session(), trigger, strategy);
+	}
+
+	/**
+	 * Scoped variant of {@link #compact(String, CompactionTrigger, CompactionStrategy)}.
+	 * {@link CompactionScope#session()} reproduces the whole-session behaviour of the
+	 * 3-arg overload exactly. {@link CompactionScope#branch(String)} restricts both the
+	 * event window fed to the trigger/strategy and the repository write to events owned by
+	 * that branch (the branch itself and its dot-prefix sub-branches) — root events and
+	 * sibling branches are loaded and archived independently and are never affected.
+	 * @param scope what this compaction pass may archive/rewrite and what counts as a turn
+	 * boundary
+	 * @return the compaction result, scoped the same way
+	 */
+	CompactionResult compact(String sessionId, CompactionScope scope, CompactionTrigger trigger,
+			CompactionStrategy strategy);
 
 }

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/CompactionRequest.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/CompactionRequest.java
@@ -32,29 +32,44 @@ import org.springframework.util.Assert;
  * @param currentEventCount total number of events in the session
  * @param currentTurnCount total number of turns in the session (a turn is a user message
  * plus all subsequent events up to the next user message)
+ * @param scope what this compaction pass may archive/rewrite and what counts as a turn
+ * boundary; {@link CompactionScope#session()} reproduces pre-scope behaviour exactly
  * @author Christian Tzolov
  * @since 2.0.0
  */
 public record CompactionRequest(Session session, List<SessionEvent> events, int currentEventCount,
-		int currentTurnCount) {
+		int currentTurnCount, CompactionScope scope) {
 
 	/**
-	 * Creates a {@code CompactionRequest} from the given session and its event list.
+	 * Creates a whole-session-scoped {@code CompactionRequest} from the given session and
+	 * its event list. Equivalent to {@code of(session, events, CompactionScope.session())}.
 	 */
 	public static CompactionRequest of(Session session, List<SessionEvent> events) {
+		return of(session, events, CompactionScope.session());
+	}
+
+	/**
+	 * Creates a {@code CompactionRequest} scoped to the given {@link CompactionScope}.
+	 * <p>
+	 * {@code currentTurnCount} counts only non-synthetic USER messages that are turn
+	 * boundaries under {@code scope} (see {@link CompactionScope#isTurnBoundary(SessionEvent)}).
+	 * For session scope this is exactly the original root-only count: sub-agents write
+	 * USER messages attributed to their own branch, and counting those would inflate the
+	 * root turn count and cause premature compaction of the root conversation. For branch
+	 * scope, the equivalent rule applies one level down — only USER messages on exactly
+	 * that branch count; USER messages on sub-branches are turn-internal.
+	 */
+	public static CompactionRequest of(Session session, List<SessionEvent> events, CompactionScope scope) {
 		Assert.notNull(session, "session must not be null");
 		Assert.notNull(events, "events must not be null");
+		Assert.notNull(scope, "scope must not be null");
 		int eventCount = events.size();
-		// Count only non-synthetic, root-level (branch == null) USER messages.
-		// Sub-agents in multi-agent sessions write USER messages attributed to their own
-		// branch; counting those would inflate the turn count and cause premature
-		// compaction of the root conversation.
 		int turnCount = (int) events.stream()
 			.filter(e -> !e.isSynthetic())
 			.filter(e -> e.getMessageType() == MessageType.USER)
-			.filter(SessionEvent::isRootEvent)
+			.filter(scope::isTurnBoundary)
 			.count();
-		return new CompactionRequest(session, events, eventCount, turnCount);
+		return new CompactionRequest(session, events, eventCount, turnCount, scope);
 	}
 
 }

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/CompactionScope.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/CompactionScope.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.compaction;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.session.EventFilter;
+import org.springframework.ai.session.SessionEvent;
+import org.springframework.util.Assert;
+
+/**
+ * Defines what a compaction pass is allowed to summarize/archive and what counts as a
+ * turn boundary for budgeting purposes.
+ *
+ * <p>
+ * Deliberately a separate type from {@link EventFilter}, because the two express
+ * <em>inverse</em> predicates:
+ * <ul>
+ * <li>{@link EventFilter#forBranch(String)} is <em>ancestor-inclusive</em> — it answers
+ * "what is visible to an agent at this branch," which includes root events and every
+ * ancestor branch.</li>
+ * <li>{@link CompactionScope#branch(String)} is <em>owned-only</em> — it answers "what
+ * may this compaction pass archive or rewrite," which must exclude root and ancestor
+ * events, since a branch must never archive events it does not own.</li>
+ * </ul>
+ * {@link EventFilter} also carries retrieval-only concerns ({@code lastN},
+ * {@code page}/{@code pageSize}, {@code keyword}, {@code from}/{@code to}) that have no
+ * meaningful interpretation as a compaction policy. Reusing it as a scope would overload
+ * a retrieval type as a lifecycle-policy type.
+ *
+ * <p>
+ * {@link #session()} reproduces the original (pre-scope) behaviour exactly: it owns every
+ * event, and only root-level ({@code branch == null}) events are turn boundaries. This is
+ * the default used everywhere compaction is not explicitly scoped to a branch.
+ *
+ * @param branch the branch this scope is restricted to, or {@code null} for whole-session
+ * scope
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public record CompactionScope(@Nullable String branch) {
+
+	/**
+	 * Whole-session scope: owns every event, and root-level ({@code branch == null})
+	 * events are turn boundaries. Reproduces pre-scope compaction behaviour exactly.
+	 */
+	public static CompactionScope session() {
+		return new CompactionScope(null);
+	}
+
+	/**
+	 * Scope restricted to the given branch and its sub-branches (e.g. {@code "planner"}
+	 * owns {@code "planner"} and {@code "planner.sub"}, but not root or sibling
+	 * branches).
+	 * @param branch the branch path this scope is restricted to; must not be
+	 * {@code null}
+	 */
+	public static CompactionScope branch(String branch) {
+		Assert.hasText(branch, "branch must not be null or empty");
+		return new CompactionScope(branch);
+	}
+
+	/** Returns {@code true} if this is whole-session scope ({@code branch == null}). */
+	public boolean isSession() {
+		return this.branch == null;
+	}
+
+	/**
+	 * Returns {@code true} if this scope may archive/rewrite the given event.
+	 * <p>
+	 * Session scope owns everything. Branch scope owns only events whose branch equals
+	 * this scope's branch or is a dot-prefix descendant of it (e.g. scope {@code
+	 * "planner"} owns branch {@code "planner.sub"}) — root and ancestor events are never
+	 * owned, since a branch compaction must never archive events a sibling or the root
+	 * conversation depends on.
+	 */
+	public boolean owns(SessionEvent event) {
+		if (isSession()) {
+			return true;
+		}
+		String eventBranch = event.getBranch();
+		return eventBranch != null && (eventBranch.equals(this.branch) || eventBranch.startsWith(this.branch + "."));
+	}
+
+	/**
+	 * Returns {@code true} if the given event counts as a turn boundary for this scope's
+	 * budgeting purposes.
+	 * <p>
+	 * Session scope: root-level ({@link SessionEvent#isRootEvent()}) events are
+	 * boundaries; branch events are turn-internal and ride along with the enclosing root
+	 * turn. Branch scope: events on exactly this branch are boundaries; events on
+	 * sub-branches (e.g. {@code "planner.sub"} under scope {@code "planner"}) are
+	 * turn-internal and ride along with the enclosing branch turn — the same nesting
+	 * rule applied one level down.
+	 */
+	public boolean isTurnBoundary(SessionEvent event) {
+		return isSession() ? event.isRootEvent() : this.branch.equals(event.getBranch());
+	}
+
+	/**
+	 * The branch a synthetic compaction summary produced under this scope should be
+	 * stamped with. {@code null} for session scope (summaries land on root, as today);
+	 * otherwise this scope's branch, so the summary is only visible within the branch it
+	 * summarizes.
+	 */
+	@Nullable public String summaryBranch() {
+		return this.branch;
+	}
+
+}

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/CompactionUtils.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/CompactionUtils.java
@@ -84,6 +84,20 @@ final class CompactionUtils {
 	/**
 	 * Advances {@code rawCutIndex} forward until it points to a root-level (null-branch)
 	 * {@link MessageType#USER} event, or to {@code real.size()} if no such event exists.
+	 * Equivalent to {@code snapToTurnStart(real, rawCutIndex, CompactionScope.session())}.
+	 * @param real the list of non-synthetic session events
+	 * @param rawCutIndex the initial cut point; must be in {@code [0, real.size()]}
+	 * @return the adjusted index pointing to the first root-level USER event at or after
+	 * {@code rawCutIndex}, or {@code real.size()} if none exists
+	 */
+	static int snapToTurnStart(List<SessionEvent> real, int rawCutIndex) {
+		return snapToTurnStart(real, rawCutIndex, CompactionScope.session());
+	}
+
+	/**
+	 * Advances {@code rawCutIndex} forward until it points to an event that is a turn
+	 * boundary under {@code scope} (see {@link CompactionScope#isTurnBoundary(SessionEvent)}),
+	 * or to {@code real.size()} if no such event exists.
 	 *
 	 * <p>
 	 * Compaction strategies compute a raw cut point (the index into the real-event list
@@ -93,13 +107,14 @@ final class CompactionUtils {
 	 * kept window always begins at a complete turn, preserving conversation semantics.
 	 * @param real the list of non-synthetic session events
 	 * @param rawCutIndex the initial cut point; must be in {@code [0, real.size()]}
-	 * @return the adjusted index pointing to the first root-level USER event at or after
+	 * @param scope the scope whose turn-boundary rule applies
+	 * @return the adjusted index pointing to the first turn-boundary event at or after
 	 * {@code rawCutIndex}, or {@code real.size()} if none exists
 	 */
-	static int snapToTurnStart(List<SessionEvent> real, int rawCutIndex) {
+	static int snapToTurnStart(List<SessionEvent> real, int rawCutIndex, CompactionScope scope) {
 		int idx = rawCutIndex;
-		while (idx < real.size()
-				&& !(real.get(idx).isRootEvent() && real.get(idx).getMessageType() == MessageType.USER)) {
+		while (idx < real.size() && !(scope.isTurnBoundary(real.get(idx)) && real.get(idx)
+			.getMessageType() == MessageType.USER)) {
 			idx++;
 		}
 		return idx;

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/RecursiveSummarizationCompactionStrategy.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/RecursiveSummarizationCompactionStrategy.java
@@ -146,26 +146,28 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 		Assert.notNull(context.session(), "session must not be null");
 
 		List<SessionEvent> events = context.events();
+		CompactionScope scope = context.scope();
 
 		List<SessionEvent> syntheticEvents = events.stream().filter(SessionEvent::isSynthetic).toList();
 		List<SessionEvent> realEvents = events.stream().filter(e -> !e.isSynthetic()).toList();
 
-		// Count only root (non-branch) real events. Branch events from sub-agent sessions
-		// are bundled with their enclosing root turns and do not consume slots from the
-		// maxEventsToKeep budget.
-		long rootEventCount = realEvents.stream().filter(SessionEvent::isRootEvent).count();
+		// Count only turn-boundary real events under scope (root-level for session scope;
+		// on-branch for branch scope). Turn-internal events (sub-agent branch events for
+		// session scope; sub-branch events for branch scope) are bundled with their
+		// enclosing turn and do not consume slots from the maxEventsToKeep budget.
+		long rootEventCount = realEvents.stream().filter(scope::isTurnBoundary).count();
 
 		if (rootEventCount <= this.maxEventsToKeep) {
 			// Nothing to compact — return as-is
 			return new CompactionResult(events, List.of(), 0);
 		}
 
-		// Find the index in realEvents just after the last root event to archive.
+		// Find the index in realEvents just after the last turn-boundary event to archive.
 		long rootEventsToArchive = rootEventCount - this.maxEventsToKeep;
 		int rawCutIndex = 0;
 		long rootSeen = 0;
 		for (int i = 0; i < realEvents.size(); i++) {
-			if (realEvents.get(i).isRootEvent()) {
+			if (scope.isTurnBoundary(realEvents.get(i))) {
 				rootSeen++;
 				if (rootSeen == rootEventsToArchive) {
 					rawCutIndex = i + 1;
@@ -174,10 +176,10 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 			}
 		}
 
-		// Snap forward to the nearest root-level turn start (USER message) so the active
+		// Snap forward to the nearest turn-boundary turn start (USER message) so the active
 		// window always begins at a turn boundary and is never a partial turn.
-		// Sub-agent USER messages (branch != null) are skipped — they are turn-internal.
-		int cutIndex = CompactionUtils.snapToTurnStart(realEvents, rawCutIndex);
+		// Turn-internal USER messages are skipped — they are turn-internal.
+		int cutIndex = CompactionUtils.snapToTurnStart(realEvents, rawCutIndex, scope);
 
 		// Split real events: archive the older ones, keep the newest window
 		List<SessionEvent> toArchive = realEvents.subList(0, cutIndex);
@@ -215,6 +217,7 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 					.sessionId(sessionId)
 					.timestamp(now)
 					.message(new UserMessage(this.shadowPrompt))
+					.branch(scope.summaryBranch())
 					.metadata(SessionEvent.METADATA_SYNTHETIC, true)
 					.metadata(SessionEvent.METADATA_COMPACTION_SOURCE, STRATEGY_NAME)
 					.build(),
@@ -222,6 +225,7 @@ public final class RecursiveSummarizationCompactionStrategy implements Compactio
 					.sessionId(sessionId)
 					.timestamp(now)
 					.message(new AssistantMessage(summary))
+					.branch(scope.summaryBranch())
 					.metadata(SessionEvent.METADATA_SYNTHETIC, true)
 					.metadata(SessionEvent.METADATA_COMPACTION_SOURCE, STRATEGY_NAME)
 					.build());

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategy.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/SlidingWindowCompactionStrategy.java
@@ -73,6 +73,7 @@ public final class SlidingWindowCompactionStrategy implements CompactionStrategy
 		Assert.notNull(context.session(), "session must not be null");
 
 		List<SessionEvent> events = context.events();
+		CompactionScope scope = context.scope();
 
 		// Separate synthetic summary events (always preserved, always first)
 		List<SessionEvent> synthetic = events.stream().filter(SessionEvent::isSynthetic).toList();
@@ -80,29 +81,31 @@ public final class SlidingWindowCompactionStrategy implements CompactionStrategy
 
 		// maxEvents controls the real-events window only; synthetic summary events are
 		// always preserved on top and do not consume slots from the real-event budget.
-		// Branch events produced inside sub-agent sessions also do not consume slots —
-		// they are always included with their enclosing root turn.
+		// Events that are turn-internal under scope (sub-agent branch events for session
+		// scope; sub-branch events for branch scope) also do not consume slots — they are
+		// always included with their enclosing turn.
 		int slotsForReal = this.maxEvents;
 
-		// Count only root (non-branch) real events to determine whether compaction is needed
-		// and where to place the raw cut. Branch events tagged with a non-null branch are
-		// turn-internal and are always carried along with their enclosing root turn.
-		long rootEventCount = real.stream().filter(SessionEvent::isRootEvent).count();
+		// Count only turn-boundary events under scope to determine whether compaction is
+		// needed and where to place the raw cut. Turn-internal events (sub-agent branch
+		// events for session scope; sub-branch events for branch scope) are turn-internal
+		// and are always carried along with their enclosing turn.
+		long rootEventCount = real.stream().filter(scope::isTurnBoundary).count();
 
-		// No-op if root events fit within the available slots
+		// No-op if turn-boundary events fit within the available slots
 		if (rootEventCount <= slotsForReal) {
 			return new CompactionResult(events, List.of(), 0);
 		}
 
-		// Find the index in 'real' just after the last root event to archive.
-		// Walk forward counting root events; place the raw cut right after the
-		// (rootEventCount - slotsForReal)-th root event so snapToTurnStart can advance
-		// it to the next root-level USER event.
+		// Find the index in 'real' just after the last turn-boundary event to archive.
+		// Walk forward counting turn-boundary events; place the raw cut right after the
+		// (rootEventCount - slotsForReal)-th such event so snapToTurnStart can advance it
+		// to the next turn-boundary USER event.
 		long rootEventsToArchive = rootEventCount - slotsForReal;
 		int rawCutIndex = 0;
 		long rootSeen = 0;
 		for (int i = 0; i < real.size(); i++) {
-			if (real.get(i).isRootEvent()) {
+			if (scope.isTurnBoundary(real.get(i))) {
 				rootSeen++;
 				if (rootSeen == rootEventsToArchive) {
 					rawCutIndex = i + 1;
@@ -113,7 +116,7 @@ public final class SlidingWindowCompactionStrategy implements CompactionStrategy
 
 		// Snap forward to the nearest turn start (USER message) so we never keep a
 		// partial turn — e.g. an assistant reply without its originating user message.
-		int cutIndex = CompactionUtils.snapToTurnStart(real, rawCutIndex);
+		int cutIndex = CompactionUtils.snapToTurnStart(real, rawCutIndex, scope);
 
 		List<SessionEvent> keptReal = new ArrayList<>(real.subList(cutIndex, real.size()));
 		List<SessionEvent> removedReal = real.subList(0, cutIndex);

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategy.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/TokenCountCompactionStrategy.java
@@ -102,10 +102,11 @@ public final class TokenCountCompactionStrategy implements CompactionStrategy {
 			}
 		}
 
-		// Snap the raw cut forward to the nearest root-level USER event so the kept
-		// window always starts at a turn boundary. Sub-agent USER messages (branch != null)
-		// are skipped — they are turn-internal, not turn starts.
-		int cutIndex = CompactionUtils.snapToTurnStart(real, rawCutIndex);
+		// Snap the raw cut forward to the nearest turn-boundary USER event (root-level for
+		// session scope; on-branch for branch scope) so the kept window always starts at a
+		// turn boundary. Turn-internal USER messages are skipped — they are turn-internal,
+		// not turn starts.
+		int cutIndex = CompactionUtils.snapToTurnStart(real, rawCutIndex, context.scope());
 
 		// Build kept and archived lists in chronological order
 		List<SessionEvent> kept = new ArrayList<>(real.subList(cutIndex, real.size()));

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategy.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategy.java
@@ -77,25 +77,26 @@ public final class TurnWindowCompactionStrategy implements CompactionStrategy {
 		Assert.notNull(request, "request must not be null");
 
 		List<SessionEvent> events = request.events();
+		CompactionScope scope = request.scope();
 
 		// 1. Separate synthetic summary events — always preserved, always first
 		List<SessionEvent> synthetic = events.stream().filter(SessionEvent::isSynthetic).toList();
 		List<SessionEvent> real = events.stream().filter(e -> !e.isSynthetic()).toList();
 
-		// 2. Collect any preamble events that appear before the first user message
-		// (e.g., pre-seeded tool context). These are kept verbatim.
+		// 2. Collect any preamble events that appear before the first turn-boundary user
+		// message (e.g., pre-seeded tool context). These are kept verbatim.
 		List<SessionEvent> preamble = new ArrayList<>();
 		int firstUserIdx = 0;
-		while (firstUserIdx < real.size()
-				&& !(real.get(firstUserIdx).isRootEvent()
-						&& real.get(firstUserIdx).getMessageType() == MessageType.USER)) {
+		while (firstUserIdx < real.size() && !(scope.isTurnBoundary(real.get(firstUserIdx))
+				&& real.get(firstUserIdx).getMessageType() == MessageType.USER)) {
 			preamble.add(real.get(firstUserIdx));
 			firstUserIdx++;
 		}
 		List<SessionEvent> afterPreamble = real.subList(firstUserIdx, real.size());
 
-		// 3. Group into turns — each turn starts at a root-level user message
-		List<List<SessionEvent>> turns = groupIntoTurns(afterPreamble);
+		// 3. Group into turns — each turn starts at a turn-boundary user message (root-level
+		// for session scope; on-branch for branch scope)
+		List<List<SessionEvent>> turns = groupIntoTurns(afterPreamble, scope);
 
 		// 4. No-op if within budget
 		if (turns.size() <= this.maxTurns) {
@@ -123,17 +124,19 @@ public final class TurnWindowCompactionStrategy implements CompactionStrategy {
 	}
 
 	/**
-	 * Groups a flat list of events into turns. Each turn starts with a root-level
-	 * ({@code branch == null}) {@link MessageType#USER} event. Sub-agent branch events are
-	 * grouped with the enclosing root turn. Assumes {@code events} begins with a root user
-	 * message (preamble has already been stripped).
+	 * Groups a flat list of events into turns. Each turn starts with an event that is a
+	 * turn boundary under {@code scope} (root-level for session scope; on-branch for
+	 * branch scope) and a {@link MessageType#USER} event. Events that are turn-internal
+	 * under {@code scope} (sub-agent branch events for session scope; sub-branch events for
+	 * branch scope) are grouped with the enclosing turn. Assumes {@code events} begins with
+	 * a turn-boundary user message (preamble has already been stripped).
 	 */
-	private static List<List<SessionEvent>> groupIntoTurns(List<SessionEvent> events) {
+	private static List<List<SessionEvent>> groupIntoTurns(List<SessionEvent> events, CompactionScope scope) {
 		List<List<SessionEvent>> turns = new ArrayList<>();
 		List<SessionEvent> currentTurn = null;
 
 		for (SessionEvent event : events) {
-			if (event.isRootEvent() && event.getMessageType() == MessageType.USER) {
+			if (scope.isTurnBoundary(event) && event.getMessageType() == MessageType.USER) {
 				if (currentTurn != null) {
 					turns.add(currentTurn);
 				}

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/compaction/CompactionRequestTests.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/compaction/CompactionRequestTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.session.Session;
 import org.springframework.ai.session.SessionEvent;
@@ -137,7 +138,41 @@ class CompactionRequestTests {
 		assertThatThrownBy(() -> CompactionRequest.of(null, List.of())).isInstanceOf(IllegalArgumentException.class);
 	}
 
+	@Test
+	void ofWithoutScopeDefaultsToSessionScope() {
+		CompactionRequest request = requestWith(List.of());
+		assertThat(request.scope()).isEqualTo(CompactionScope.session());
+	}
+
+	// --- branch scope ---
+
+	@Test
+	void branchScopeCountsOnlyOwnBranchUserMessagesAsTurns() {
+		// planner turn 1: [planner-q1, planner-a1]; planner.sub exchange inside it;
+		// planner turn 2: [planner-q2, planner-a2]; a root turn interleaved (must not count)
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(branchEvent(new UserMessage("planner-q1"), "planner"));
+		events.add(branchEvent(new AssistantMessage("planner-a1"), "planner"));
+		events.add(branchEvent(new UserMessage("sub-q"), "planner.sub"));
+		events.add(branchEvent(new AssistantMessage("sub-a"), "planner.sub"));
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("root-q")).build());
+		events.add(branchEvent(new UserMessage("planner-q2"), "planner"));
+		events.add(branchEvent(new AssistantMessage("planner-a2"), "planner"));
+
+		Session session = Session.builder().id(SESSION_ID).userId("test-user").build();
+		CompactionRequest request = CompactionRequest.of(session, events, CompactionScope.branch("planner"));
+
+		// Only planner-q1 and planner-q2 count; planner.sub-q and root-q do not.
+		assertThat(request.currentTurnCount()).isEqualTo(2);
+		assertThat(request.currentEventCount()).isEqualTo(7);
+		assertThat(request.scope()).isEqualTo(CompactionScope.branch("planner"));
+	}
+
 	// --- helper ---
+
+	private static SessionEvent branchEvent(Message message, String branch) {
+		return SessionEvent.builder().sessionId(SESSION_ID).message(message).branch(branch).build();
+	}
 
 	private CompactionRequest requestWith(List<SessionEvent> events) {
 		Session session = Session.builder().id(SESSION_ID).userId("test-user").build();

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/compaction/CompactionScopeTests.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/compaction/CompactionScopeTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.compaction;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.session.SessionEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link CompactionScope}.
+ */
+class CompactionScopeTests {
+
+	private static final String SESSION_ID = "test-session";
+
+	// --- session() ---
+
+	@Test
+	void sessionScopeIsSession() {
+		assertThat(CompactionScope.session().isSession()).isTrue();
+		assertThat(CompactionScope.session().branch()).isNull();
+	}
+
+	@Test
+	void sessionScopeOwnsEveryEvent() {
+		CompactionScope scope = CompactionScope.session();
+		assertThat(scope.owns(rootEvent())).isTrue();
+		assertThat(scope.owns(branchEvent("planner"))).isTrue();
+		assertThat(scope.owns(branchEvent("planner.sub"))).isTrue();
+	}
+
+	@Test
+	void sessionScopeTurnBoundaryIsRootEventOnly() {
+		CompactionScope scope = CompactionScope.session();
+		assertThat(scope.isTurnBoundary(rootEvent())).isTrue();
+		assertThat(scope.isTurnBoundary(branchEvent("planner"))).isFalse();
+	}
+
+	@Test
+	void sessionScopeSummaryBranchIsNull() {
+		assertThat(CompactionScope.session().summaryBranch()).isNull();
+	}
+
+	// --- branch(...) ---
+
+	@Test
+	void branchScopeIsNotSession() {
+		assertThat(CompactionScope.branch("planner").isSession()).isFalse();
+		assertThat(CompactionScope.branch("planner").branch()).isEqualTo("planner");
+	}
+
+	@Test
+	void branchScopeOwnsExactBranchAndSubBranches() {
+		CompactionScope scope = CompactionScope.branch("planner");
+		assertThat(scope.owns(branchEvent("planner"))).isTrue();
+		assertThat(scope.owns(branchEvent("planner.sub"))).isTrue();
+		assertThat(scope.owns(branchEvent("planner.sub.deep"))).isTrue();
+	}
+
+	@Test
+	void branchScopeDoesNotOwnRootOrAncestorOrSiblingEvents() {
+		CompactionScope scope = CompactionScope.branch("planner");
+		assertThat(scope.owns(rootEvent())).isFalse(); // root — must not be archived by a branch compaction
+		assertThat(scope.owns(branchEvent("researcher"))).isFalse(); // sibling
+		assertThat(scope.owns(branchEvent("plan"))).isFalse(); // NOT a dot-prefix ancestor match — "plan" != "planner"
+	}
+
+	@Test
+	void branchScopeTurnBoundaryIsExactBranchOnly() {
+		CompactionScope scope = CompactionScope.branch("planner");
+		assertThat(scope.isTurnBoundary(branchEvent("planner"))).isTrue();
+		// sub-branch events are turn-internal, not boundaries — mirrors root/branch nesting
+		assertThat(scope.isTurnBoundary(branchEvent("planner.sub"))).isFalse();
+		assertThat(scope.isTurnBoundary(rootEvent())).isFalse();
+	}
+
+	@Test
+	void branchScopeSummaryBranchIsTheScopeBranch() {
+		assertThat(CompactionScope.branch("planner").summaryBranch()).isEqualTo("planner");
+	}
+
+	@Test
+	void branchRejectsNullOrBlank() {
+		assertThatThrownBy(() -> CompactionScope.branch(null)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> CompactionScope.branch("")).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> CompactionScope.branch("   ")).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	// --- helpers ---
+
+	private static SessionEvent rootEvent() {
+		return SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("root")).build();
+	}
+
+	private static SessionEvent branchEvent(String branch) {
+		return SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("msg")).branch(branch).build();
+	}
+
+}

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategyTests.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/compaction/TurnWindowCompactionStrategyTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.session.Session;
@@ -344,6 +345,49 @@ class TurnWindowCompactionStrategyTests {
 		assertThat(result.compactedEvents()).hasSize(4); // [sub-q, sub-a, u2, a2]
 		assertThat(result.compactedEvents().get(0).getMessage().getText()).isEqualTo("sub-q");
 		assertThat(result.compactedEvents().get(2).getMessage().getText()).isEqualTo("u2");
+	}
+
+	// --- branch scope ---
+
+	@Test
+	void branchScopeCompactsOnlyThePlannerBranchLeavingRootAndSiblingsIntact() {
+		// planner: 3 turns; researcher: 1 turn (sibling — must be untouched); root: 1 turn
+		// (must be untouched). maxTurns=1 under CompactionScope.branch("planner") should
+		// archive planner's first 2 turns and keep only its last turn, root and researcher untouched.
+		TurnWindowCompactionStrategy strategy = TurnWindowCompactionStrategy.builder().maxTurns(1).build();
+
+		List<SessionEvent> events = new ArrayList<>();
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage("root-q")).build());
+		events.add(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("root-a")).build());
+		events.add(branchEvent(new UserMessage("planner-q1"), "planner"));
+		events.add(branchEvent(new AssistantMessage("planner-a1"), "planner"));
+		events.add(branchEvent(new UserMessage("planner-q2"), "planner"));
+		events.add(branchEvent(new AssistantMessage("planner-a2"), "planner"));
+		events.add(branchEvent(new UserMessage("planner-q3"), "planner"));
+		events.add(branchEvent(new AssistantMessage("planner-a3"), "planner"));
+		events.add(branchEvent(new UserMessage("researcher-q"), "researcher"));
+		events.add(branchEvent(new AssistantMessage("researcher-a"), "researcher"));
+
+		Session session = Session.builder().id(SESSION_ID).userId("test-user").build();
+		CompactionRequest request = CompactionRequest.of(session, events, CompactionScope.branch("planner"));
+
+		CompactionResult result = strategy.compact(request);
+
+		// Archived: only planner's first two turns (4 events) — root and researcher are
+		// never touched by a "planner"-scoped compaction.
+		assertThat(result.archivedEvents()).extracting(e -> e.getMessage().getText())
+			.containsExactly("planner-q1", "planner-a1", "planner-q2", "planner-a2");
+
+		// Kept: root turn (not a "planner" turn boundary, so it never entered the turn
+		// grouping and rides along as preamble) + planner's last turn + the researcher
+		// turn (turn-internal relative to "planner" scope, bundled with the enclosing kept
+		// planner turn — never archived, exactly like branch events ride along with root).
+		assertThat(result.compactedEvents()).extracting(e -> e.getMessage().getText())
+			.containsExactly("root-q", "root-a", "planner-q3", "planner-a3", "researcher-q", "researcher-a");
+	}
+
+	private static SessionEvent branchEvent(Message message, String branch) {
+		return SessionEvent.builder().sessionId(SESSION_ID).message(message).branch(branch).build();
 	}
 
 	// --- helpers ---


### PR DESCRIPTION
Stacked on #36 (please review that first).

This PR wires `CompactionScope` through `SessionService` into the repository layer, enabling **branch-scoped compaction**.

### Changes

* Added `SessionService.compact(sessionId, EventFilter, ...)` for targeted compaction.
* Updated `DefaultSessionService` to respect the provided filter instead of always using `EventFilter.active()`.
* Added scoped `compactEvents` overloads to `SessionRepository`, implemented for both in-memory and JDBC repositories.
* JDBC branch matching uses a dialect-independent `LIKE` predicate, requiring no schema migration.
