### PR TITLE
Add cross-session keyword/pattern search for EventFilter and CrossSessionRecallTools

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,8 +41,8 @@ Spring AI Session solves this with three ideas working together:
 
 - **Event-sourced conversation log** — append-only, immutable `SessionEvent` records
   wrapping Spring AI `Message` types
-- **Composable event filtering** — filter by message type, time range, keyword, branch,
-  last-N, or pagination
+- **Composable event filtering** — filter by message type, time range, single or
+  multi-term keyword (`ANY`/`ALL`), regular expression, branch, last-N, or pagination
 - **Four compaction strategies** out of the box:
     - `SlidingWindowCompactionStrategy` — keep the last N real events
     - `TurnWindowCompactionStrategy` — keep the last N complete turns
@@ -55,8 +55,10 @@ Spring AI Session solves this with three ideas working together:
   concurrent requests without locking
 - **Multi-agent branch isolation** — dot-separated branch labels let peer sub-agents share
   one session while hiding each other's events
-- **Recall storage tool** — `SessionEventTools` gives the model a `conversation_search`
-  tool to keyword-search the full verbatim history even after compaction
+- **Recall storage tools** — `SessionEventTools` gives the model a `conversation_search`
+  tool to keyword-search the full verbatim history of the current session even after
+  compaction; `CrossSessionRecallTools` gives a background/maintenance agent a
+  `cross_session_search` tool to mine signal across *every* session a user has
 - **Spring Boot auto-configuration** for the JDBC repository (schema init, dialect
   detection, `JdbcSessionRepository` bean)
 

--- a/docs/session-jdbc/index.md
+++ b/docs/session-jdbc/index.md
@@ -140,6 +140,22 @@ compaction safe under concurrent access.
 JSON blob) so `EventFilter.excludeSynthetic()` translates to a SQL predicate instead of
 an in-process scan.
 
+**`EventFilter.keyword()`/`keywords()`** both translate to SQL `LIKE` predicates —
+`keyword` as a single `AND LOWER(...) LIKE ?` clause, `keywords` as N such clauses joined
+with `AND`/`OR` per `matchMode`, one bound parameter per term. Every term is bound as a
+JDBC parameter, never concatenated into the SQL text.
+
+**`EventFilter.pattern()` falls back to in-memory filtering.** A `java.util.regex.Pattern`
+cannot be safely translated to portable SQL — H2, MySQL, and PostgreSQL each have their
+own regex dialect, none a strict superset of Java's regex syntax (backreferences,
+lookaround, named groups). When `pattern` is set, every other criterion is still pushed
+down to SQL as usual, but pagination (`lastN`/`page`/`pageSize`) is deferred: the full
+SQL-filtered result set is fetched, `pattern` (and, redundantly but harmlessly, every
+other criterion) is re-checked via `EventFilter.matches()` in Java, and pagination is
+applied afterward — mirroring how `InMemorySessionRepository` filters and paginates.
+Expect a `pattern` query to scan more of a session's event history than an equivalent
+`keyword`/`keywords` query.
+
 ---
 
 ## See also

--- a/docs/session-management/cross-session-recall.md
+++ b/docs/session-management/cross-session-recall.md
@@ -1,0 +1,145 @@
+# Cross-Session Recall
+
+`CrossSessionRecallTools` searches **every session belonging to one user**, not just the
+session the current request is scoped to. It exists for background/maintenance agents —
+the motivating case is a memory-consolidation agent that periodically mines a user's full
+conversation history for signal (corrections, explicit "remember this" requests,
+decisions) — not for the live conversational agent answering the user directly.
+
+---
+
+## How this differs from `conversation_search`
+
+| | [`conversation_search`](recall-storage.md) | `cross_session_search` |
+|---|---|---|
+| Scope | One session | Every session belonging to one user |
+| Session/user resolved from | `ToolContext`, automatically, per request | Bound once at **construction time** |
+| Who can change the scope | The calling application, via `SessionMemoryAdvisor` | Nobody at runtime — fixed for the tool instance's lifetime |
+| Intended caller | The live conversational agent, mid-chat | A background/maintenance agent running out-of-band |
+| Query power | Single keyword | Multi-term (`ANY`/`ALL`), plus `since` date scoping |
+| Result shape | `timestamp`, `type`, `text` | Same, plus `sessionId` |
+
+The scope difference is deliberate, not incidental. The target user is bound in Java code
+via [`builder(SessionService, String)`](#registration) rather than accepted as a tool-call
+parameter, specifically so a misbehaving or manipulated prompt cannot talk the tool into
+scanning a different user's sessions — the model never gets a parameter through which it
+could choose. Register `CrossSessionRecallTools` only on the `ChatClient` instances that
+should have this broader capability (e.g. an isolated background-agent `ChatClient`); never
+alongside `conversation_search` on the live user-facing agent, which should keep the
+narrower, request-scoped tool.
+
+---
+
+## Registration
+
+```java
+CrossSessionRecallTools tools = CrossSessionRecallTools.builder(sessionService, "alice").build();
+
+// Custom page size (default EventFilter.DEFAULT_PAGE_SIZE = 10)
+CrossSessionRecallTools tools = CrossSessionRecallTools.builder(sessionService, "alice")
+    .pageSize(20)
+    .build();
+
+ChatClient client = ChatClient.builder(chatModel)
+    .defaultTools(tools)
+    .build();
+```
+
+There is no advisor dependency here — unlike `SessionEventTools`, `CrossSessionRecallTools`
+does not read anything from `ToolContext`. The `userId` passed to `builder(...)` is fixed
+for the tool instance's entire lifetime.
+
+---
+
+## Tool signature
+
+The `cross_session_search` tool is automatically discovered by Spring AI's tool mechanism.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `innerThought` | yes | Agent's private reasoning (not returned to the caller) |
+| `query` | yes | Case-insensitive keyword, or comma-separated keywords (up to 20 terms per call) |
+| `matchMode` | no | `"any"` (default) or `"all"` — how multiple comma-separated keywords in `query` combine |
+| `since` | no | ISO-8601 instant (e.g. `2026-07-01T00:00:00Z`); only events at or after this time are considered. Omit to search the full history |
+| `page` | no | Zero-indexed result page; defaults to `0`; negative values are clamped to `0` |
+
+Results are aggregated across every session belonging to the configured user, sorted
+chronologically by the actual event `Instant` (not a string comparison — see
+[Design notes](#design-notes)), and returned as a JSON array:
+
+```json
+[
+  { "sessionId": "sess-123", "timestamp": "2025-06-01T12:00:00Z", "type": "user", "text": "We decided to use PostgreSQL" },
+  { "sessionId": "sess-456", "timestamp": "2025-06-03T09:15:00Z", "type": "user", "text": "Actually, let's go with blue-green deploys" }
+]
+```
+
+When nothing matches: `"No results found."` is returned.
+
+---
+
+## Multi-term queries
+
+Supply comma-separated terms in `query` to search for more than one term at once:
+
+```
+query = "we decided, let's go with"        matchMode = (omitted → "any")
+```
+
+matches an event whose text contains **either** term. Set `matchMode = "all"` to require
+**every** term to be present in the same event's text. A `query` that yields zero usable
+terms after splitting and trimming (e.g. `","` or `", "`) is rejected with an error rather
+than silently falling back to "no filter" — see [Design notes](#design-notes).
+
+The term count is capped at 20 per call (`CrossSessionRecallTools.MAX_QUERY_TERMS`). Each
+term becomes its own predicate — and, on a JDBC-backed `SessionService`, its own bound SQL
+parameter — so an unbounded term count would let a single call grow the generated query
+without limit. This is a sanity limit, not a security boundary in itself: every term is
+still safely bound, never concatenated into SQL text, regardless of the cap.
+
+---
+
+## Date-scoped queries
+
+Pass `since` to only consider events at or after a given instant — useful for an agent
+that runs periodically and only wants to see what's new since its last pass:
+
+```
+since = "2026-07-01T00:00:00Z"
+```
+
+A malformed `since` (e.g. a date without a time component) is rejected with a clear error
+naming the expected format, rather than propagating a raw parser exception.
+
+---
+
+## Design notes
+
+- **Read-only.** `CrossSessionRecallTools` has no append/compact/delete capability — it can
+  only call `SessionService.findByUserId(...)` and `SessionService.getEvents(...)`.
+- **Aggregation happens client-side.** Because results span multiple sessions, each
+  matching session is queried individually via `SessionService.getEvents(sessionId,
+  filter)`, and the results are merged and sorted afterward — by the events' actual
+  `Instant` timestamps, not by comparing their string renderings (`Instant.toString()`
+  omits the fractional-seconds component when it is exactly zero but includes it
+  otherwise, so two rendered timestamps of different lengths do not always compare in
+  chronological order).
+- **No per-session pagination pushdown.** Each session's full matching event set is
+  fetched before pagination is applied to the aggregate — cost scales with a user's total
+  historical event count across all sessions, not just the page size requested. Fine for
+  typical usage; worth keeping in mind for a user with a very large number of long-lived
+  sessions.
+- **`pattern`/regex is intentionally not exposed here.** `EventFilter` supports a
+  `pattern` criterion (see [Event Filtering](event-filtering.md)), but
+  `cross_session_search` only exposes plain-substring `keywords`/`matchMode` search — never
+  a raw regex string a model could supply. See the ReDoS warning on
+  [Event Filtering](event-filtering.md#static-factory-shortcuts) for why.
+
+---
+
+## See also
+
+- [Recall Storage](recall-storage.md) — the single-session `conversation_search` tool this
+  complements
+- [Event Filtering](event-filtering.md) — the full `EventFilter` API, including
+  `keywords`/`matchMode`/`pattern`

--- a/docs/session-management/event-filtering.md
+++ b/docs/session-management/event-filtering.md
@@ -29,9 +29,29 @@ service.getEvents(id, EventFilter.keywordSearch("Spring AI"));
 // Keyword search — explicit page and page size
 service.getEvents(id, EventFilter.keywordSearch("Spring AI", 1, 5));
 
+// Multi-term search — match ANY of the terms (case-insensitive substring per term)
+service.getEvents(id, EventFilter.keywordsSearch(List.of("no,", "don't", "actually"), MatchMode.ANY));
+
+// Multi-term search — match ALL of the terms
+service.getEvents(id, EventFilter.keywordsSearch(List.of("we decided", "going forward"), MatchMode.ALL));
+
+// Regular-expression search — first page (default page size 10)
+service.getEvents(id, EventFilter.patternSearch(Pattern.compile("\\bwe decided\\b")));
+
 // Events visible to a specific agent branch (own + ancestor events only)
 service.getEvents(id, EventFilter.forBranch("orch.researcher"));
 ```
+
+!!! danger "Never compile an untrusted string into the `pattern` argument"
+    `patternSearch(Pattern)` and `Builder.pattern(Pattern)` take an already-compiled
+    `java.util.regex.Pattern` — a **Java-level API**, not a tool-call parameter. Never call
+    `Pattern.compile(...)` on a string sourced from a user, an LLM tool-call argument, or
+    any other untrusted input and pass the result here: an attacker-chosen expression can
+    exhibit catastrophic backtracking (ReDoS) when evaluated against attacker-influenced
+    message text. Only pass patterns compiled from a fixed or developer-authored
+    expression. This is exactly why no `@Tool`-annotated method in this library accepts a
+    raw regex string — see [Cross-Session Recall](cross-session-recall.md), which
+    deliberately exposes only plain-substring `keywords`/`matchMode` search instead.
 
 ---
 
@@ -46,9 +66,16 @@ EventFilter filter = EventFilter.builder()
     .excludeSynthetic(true)                                // exclude summary events
     .lastN(50)                                             // keep newest 50 matches
     .keyword("Spring AI")                                  // case-insensitive substring
+    .keywords(List.of("no,", "actually"))                  // multi-term substring match
+    .matchMode(MatchMode.ANY)                               // ANY (default) or ALL of keywords
+    .pattern(Pattern.compile("\\bwe decided\\b"))          // compiled regex — developer-authored only
     .branch("orch.researcher")                             // branch isolation
     .build();
 ```
+
+`keyword`, `keywords`, and `pattern` are independent criteria that all compose with
+AND-together semantics in `matches()` — set more than one and an event must satisfy every
+one of them, not just one. In practice, callers set exactly one of the three.
 
 ---
 
@@ -62,6 +89,9 @@ EventFilter filter = EventFilter.builder()
 | `excludeSynthetic` | `boolean` | When `true`, synthetic summary events are excluded |
 | `lastN` | `Integer` | Keep only the most recent N matching events (must be > 0) |
 | `keyword` | `String` | Case-insensitive substring match on `message.getText()` |
+| `keywords` | `List<String>` | Multiple case-insensitive substring terms, combined per `matchMode` |
+| `matchMode` | `MatchMode` | `ANY` (at least one term present) or `ALL` (every term present) — only meaningful when `keywords` is set |
+| `pattern` | `Pattern` | Compiled regular expression matched against `message.getText()` via `Matcher.find()`. **Only ever pass a developer-authored `Pattern`** — see the ReDoS warning above |
 | `page` | `Integer` | Zero-indexed page in chronological order (oldest first, page 0 = oldest) |
 | `pageSize` | `Integer` | Results per page (default 10; must be > 0 if set) |
 | `branch` | `String` | Restricts to events visible to this agent branch (own + ancestors only) |
@@ -79,6 +109,12 @@ The compact constructor enforces these rules at construction time:
 - **Setting `pageSize` without `page`** is allowed — `page` defaults to `0` (first page).
 - **`keyword`** is normalised on construction: blank or empty strings become `null`;
   non-null values are lowercased for case-insensitive matching.
+- **`keywords`** is normalised on construction the same way, term by term: `null`/blank
+  entries are dropped and survivors are lowercased. An empty or all-blank list normalises
+  to `null` (equivalent to no multi-term filter).
+- **`matchMode`** defaults to `ANY` when `keywords` is set and `matchMode` is left `null`.
+  If `keywords` is `null`, `matchMode` is forced to `null` too — even if you set one
+  explicitly — since it has nothing to apply to.
 - **`messageTypes`** is normalised on construction: an empty set becomes `null`
   (equivalent to no type filter).
 

--- a/docs/session-management/recall-storage.md
+++ b/docs/session-management/recall-storage.md
@@ -10,6 +10,12 @@ active window are flagged `SessionEvent.isArchived()` and kept in the log. The a
 context window the advisor injects is the `EventFilter.active()` view (archived events
 excluded), while `conversation_search` searches the whole log (archived events included).
 
+!!! tip "Need to search across a user's other sessions, not just this one?"
+    `conversation_search` is deliberately scoped to a single session, resolved
+    automatically from the live request — the model never chooses which session it
+    searches. For a background/maintenance agent that needs to mine signal across **every**
+    session a user has, see [Cross-Session Recall](cross-session-recall.md) instead.
+
 ---
 
 ## Registration
@@ -90,3 +96,11 @@ page=1  →  next 10 matching events
 
 The model can call `conversation_search` multiple times with incrementing `page` values to
 paginate through the full history until it finds what it needs.
+
+---
+
+## See also
+
+- [Cross-Session Recall](cross-session-recall.md) — the analogous tool scoped to *every*
+  session belonging to a user, for background/maintenance agents
+- [Event Filtering](event-filtering.md) — the full `EventFilter` API this tool builds on

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - ChatClient Integration: session-management/chat-client.md
       - Multi-Agent Branch Isolation: session-management/multi-agent.md
       - Recall Storage: session-management/recall-storage.md
+      - Cross-Session Recall: session-management/cross-session-recall.md
   - Session JDBC:
       - Overview & Setup: session-jdbc/index.md
       - Auto-configuration: session-jdbc/auto-configuration.md

--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
@@ -271,6 +272,16 @@ public final class JdbcSessionRepository implements SessionRepository {
 		Assert.hasText(sessionId, "sessionId must not be null or empty");
 		Assert.notNull(filter, "filter must not be null");
 
+		// A java.util.regex.Pattern cannot be safely translated to portable SQL — H2,
+		// MySQL, and PostgreSQL each have their own regex dialect, none of which is a
+		// strict superset of Java's regex syntax (backreferences, lookaround, named
+		// groups). When `pattern` is set, every other criterion is still pushed down to
+		// SQL as usual, but LIMIT/OFFSET is deferred: the pattern (and, redundantly but
+		// harmlessly, every other criterion) is re-checked in Java via EventFilter.matches
+		// against the full SQL-filtered result, then lastN/page/pageSize is applied
+		// in-memory — mirroring how InMemorySessionRepository filters and paginates.
+		boolean patternRequiresInMemoryFiltering = filter.pattern() != null;
+
 		StringBuilder sql = new StringBuilder(SELECT_EVENTS_BASE);
 		List<Object> params = new ArrayList<>();
 		params.add(sessionId);
@@ -309,8 +320,23 @@ public final class JdbcSessionRepository implements SessionRepository {
 			sql.append(this.dialect.getKeywordFilterFragment()).append(" ");
 			params.add("%" + filter.keyword() + "%");
 		}
+		if (filter.keywords() != null) {
+			sql.append("AND (");
+			String joiner = filter.matchMode() == EventFilter.MatchMode.ALL ? " AND " : " OR ";
+			for (int i = 0; i < filter.keywords().size(); i++) {
+				if (i > 0) {
+					sql.append(joiner);
+				}
+				sql.append(this.dialect.getKeywordPredicateFragment());
+				params.add("%" + filter.keywords().get(i) + "%");
+			}
+			sql.append(") ");
+		}
 
-		if (filter.lastN() != null) {
+		if (patternRequiresInMemoryFiltering) {
+			sql.append("ORDER BY e.seq ASC ");
+		}
+		else if (filter.lastN() != null) {
 			sql.append("ORDER BY e.seq DESC LIMIT ? ");
 			params.add(filter.lastN());
 		}
@@ -327,12 +353,43 @@ public final class JdbcSessionRepository implements SessionRepository {
 		List<SessionEvent> result = this.jdbcTemplate.query(sql.toString(), new SessionEventRowMapper(),
 				params.toArray());
 
-		if (filter.lastN() != null) {
+		if (patternRequiresInMemoryFiltering) {
+			result = result.stream().filter(filter::matches).collect(Collectors.toCollection(ArrayList::new));
+			result = applyInMemoryPagination(result, filter);
+		}
+		else if (filter.lastN() != null) {
 			result = new ArrayList<>(result);
 			Collections.reverse(result);
 		}
 
 		return Collections.unmodifiableList(result);
+	}
+
+	/**
+	 * Applies {@code lastN} / {@code page}+{@code pageSize} slicing to an already
+	 * fully-filtered, seq-ascending event list. Only used on the {@code pattern}
+	 * in-memory-filtering path above, where SQL-level LIMIT/OFFSET can't be used because
+	 * the pattern criterion is only evaluated after the query runs. Mirrors
+	 * InMemorySessionRepository's pagination so both backends behave identically.
+	 */
+	private static List<SessionEvent> applyInMemoryPagination(List<SessionEvent> matched, EventFilter filter) {
+		if (filter.lastN() != null) {
+			if (matched.size() > filter.lastN()) {
+				return new ArrayList<>(matched.subList(matched.size() - filter.lastN(), matched.size()));
+			}
+			return matched;
+		}
+		if (filter.pageSize() != null) {
+			int page = filter.page() != null ? filter.page() : 0;
+			long fromIndexLong = (long) page * filter.pageSize();
+			if (fromIndexLong >= matched.size()) {
+				return new ArrayList<>();
+			}
+			int fromIndex = (int) fromIndexLong;
+			int toIndex = (int) Math.min(fromIndexLong + filter.pageSize(), matched.size());
+			return new ArrayList<>(matched.subList(fromIndex, toIndex));
+		}
+		return matched;
 	}
 
 	// -------------------------------------------------------------------------

--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryDialect.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryDialect.java
@@ -72,6 +72,26 @@ public interface JdbcSessionRepositoryDialect {
 	String getKeywordFilterFragment();
 
 	/**
+	 * Case-insensitive substring <em>predicate</em> — no leading {@code AND}, exactly one
+	 * {@code ?} placeholder — against the event's message content. Used by
+	 * {@code JdbcSessionRepository} to build the multi-term
+	 * {@link org.springframework.ai.session.EventFilter#keywords()} /
+	 * {@link org.springframework.ai.session.EventFilter#matchMode()} filter, repeating
+	 * this predicate once per term and joining with {@code AND}/{@code OR} depending on
+	 * match mode (e.g. {@code AND (pred OR pred OR pred)}).
+	 *
+	 * <p>
+	 * Defaults to the same expression as {@link #getKeywordFilterFragment()} minus the
+	 * {@code AND } prefix, which is correct for every dialect shipped today (they all use
+	 * identical {@code LOWER(COALESCE(...)) LIKE ?} SQL — only branch-visibility
+	 * concatenation actually differs across databases). Override only if a future dialect
+	 * needs different substring-match SQL.
+	 */
+	default String getKeywordPredicateFragment() {
+		return "LOWER(COALESCE(e.message_content, '')) LIKE ?";
+	}
+
+	/**
 	 * Branch visibility filter fragment for multi-agent event isolation. The clause
 	 * matches events that are visible to the given branch: root events (null branch),
 	 * exact branch match, or ancestor branches (the caller is a descendant).

--- a/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
+++ b/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import javax.sql.DataSource;
 
@@ -31,6 +32,7 @@ import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.session.EventFilter;
+import org.springframework.ai.session.EventFilter.MatchMode;
 import org.springframework.ai.session.Session;
 import org.springframework.ai.session.SessionEvent;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -283,6 +285,93 @@ class JdbcSessionRepositoryTests {
 		List<SessionEvent> results = this.repository.findEvents(session.id(), EventFilter.keywordSearch("hello"));
 		assertThat(results).hasSize(2);
 		assertThat(results).allMatch(e -> e.getMessage().getText().toLowerCase().contains("hello"));
+	}
+
+	@Test
+	void findEventsKeywordsAnyMatchSearch() {
+		Session session = buildSession("user-kws-any");
+		this.repository.save(session);
+
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("we decided to ship it")).build());
+		this.repository.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("let's go with option B"))
+			.build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("unrelated message")).build());
+
+		List<SessionEvent> results = this.repository.findEvents(session.id(),
+				EventFilter.keywordsSearch(List.of("we decided", "let's go with"), MatchMode.ANY));
+
+		assertThat(results).extracting(e -> e.getMessage().getText())
+			.containsExactlyInAnyOrder("we decided to ship it", "let's go with option B");
+	}
+
+	@Test
+	void findEventsKeywordsAllMatchSearchRequiresEveryTerm() {
+		Session session = buildSession("user-kws-all");
+		this.repository.save(session);
+
+		this.repository.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.message(new UserMessage("actually, let's use this instead"))
+			.build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("actually that's fine as-is")).build());
+
+		List<SessionEvent> results = this.repository.findEvents(session.id(),
+				EventFilter.keywordsSearch(List.of("actually", "instead"), MatchMode.ALL));
+
+		assertThat(results).extracting(e -> e.getMessage().getText())
+			.containsExactly("actually, let's use this instead");
+	}
+
+	@Test
+	void findEventsPatternSearch() {
+		Session session = buildSession("user-pattern");
+		this.repository.save(session);
+
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("we decided on option B")).build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("we haven't decided yet")).build());
+
+		List<SessionEvent> results = this.repository.findEvents(session.id(),
+				EventFilter.patternSearch(Pattern.compile("\\bwe decided\\b")));
+
+		assertThat(results).extracting(e -> e.getMessage().getText()).containsExactly("we decided on option B");
+	}
+
+	@Test
+	void findEventsPatternSearchCombinedWithPagination() {
+		Session session = buildSession("user-pattern-page");
+		this.repository.save(session);
+
+		// Ordering is by insertion-derived `seq`, not timestamp, so the non-matching
+		// event must be interleaved by *append order* — inserted between entry 2 and
+		// entry 3 — to actually prove the pattern filter is applied before pagination
+		// slices the result, not just after (offset=2 on the unfiltered 7-row set would
+		// wrongly land on "no match here" instead of entry 3 if pagination ran in SQL).
+		appendEntry(session.id(), 1);
+		appendEntry(session.id(), 2);
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("no match here")).build());
+		appendEntry(session.id(), 3);
+		appendEntry(session.id(), 4);
+		appendEntry(session.id(), 5);
+		appendEntry(session.id(), 6);
+
+		List<SessionEvent> page0 = this.repository.findEvents(session.id(),
+				EventFilter.builder().pattern(Pattern.compile("^entry \\d$")).page(0).pageSize(2).build());
+		List<SessionEvent> page1 = this.repository.findEvents(session.id(),
+				EventFilter.builder().pattern(Pattern.compile("^entry \\d$")).page(1).pageSize(2).build());
+		List<SessionEvent> page2 = this.repository.findEvents(session.id(),
+				EventFilter.builder().pattern(Pattern.compile("^entry \\d$")).page(2).pageSize(2).build());
+
+		assertThat(page0).extracting(e -> e.getMessage().getText()).containsExactly("entry 1", "entry 2");
+		assertThat(page1).extracting(e -> e.getMessage().getText()).containsExactly("entry 3", "entry 4");
+		assertThat(page2).extracting(e -> e.getMessage().getText()).containsExactly("entry 5", "entry 6");
 	}
 
 	@Test
@@ -643,6 +732,11 @@ class JdbcSessionRepositoryTests {
 
 	private Session buildSession(String userId) {
 		return Session.builder().id(UUID.randomUUID().toString()).userId(userId).build();
+	}
+
+	private void appendEntry(String sessionId, int n) {
+		this.repository
+			.appendEvent(SessionEvent.builder().sessionId(sessionId).message(new UserMessage("entry " + n)).build());
 	}
 
 	// -------------------------------------------------------------------------

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/EventFilter.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/EventFilter.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.session;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
 
@@ -71,11 +73,29 @@ import org.springframework.ai.chat.messages.MessageType;
  * @since 2.0.0
  */
 public record EventFilter(@Nullable Instant from, @Nullable Instant to, @Nullable Set<MessageType> messageTypes,
-		boolean excludeSynthetic, @Nullable Integer lastN, @Nullable String keyword, @Nullable Integer page,
-		@Nullable Integer pageSize, @Nullable String branch, boolean excludeArchived) {
+		boolean excludeSynthetic, @Nullable Integer lastN, @Nullable String keyword,
+		@Nullable List<String> keywords, @Nullable MatchMode matchMode, @Nullable Pattern pattern,
+		@Nullable Integer page, @Nullable Integer pageSize, @Nullable String branch, boolean excludeArchived) {
+
+	/**
+	 * How multiple {@link #keywords()} combine when matching an event's text.
+	 */
+	public enum MatchMode {
+
+		/** Match if the text contains at least one of the keywords. */
+		ANY,
+
+		/** Match only if the text contains all of the keywords. */
+		ALL
+
+	}
 
 	public EventFilter {
 		keyword = (keyword != null && !keyword.isBlank()) ? keyword.toLowerCase() : null;
+		keywords = (keywords != null && !keywords.isEmpty())
+				? keywords.stream().filter(k -> k != null && !k.isBlank()).map(String::toLowerCase).toList() : null;
+		keywords = (keywords != null && keywords.isEmpty()) ? null : keywords;
+		matchMode = (keywords != null) ? (matchMode != null ? matchMode : MatchMode.ANY) : null;
 		messageTypes = (messageTypes != null && !messageTypes.isEmpty()) ? messageTypes : null;
 		if (lastN != null && lastN <= 0) {
 			throw new IllegalArgumentException("lastN must be greater than 0");
@@ -101,7 +121,10 @@ public record EventFilter(@Nullable Instant from, @Nullable Instant to, @Nullabl
 		return new EventFilter(other.from != null ? other.from : this.from, other.to != null ? other.to : this.to,
 				other.messageTypes != null ? other.messageTypes : this.messageTypes,
 				other.excludeSynthetic || this.excludeSynthetic, other.lastN != null ? other.lastN : this.lastN,
-				other.keyword != null ? other.keyword : this.keyword, other.page != null ? other.page : this.page,
+				other.keyword != null ? other.keyword : this.keyword,
+				other.keywords != null ? other.keywords : this.keywords,
+				other.matchMode != null ? other.matchMode : this.matchMode,
+				other.pattern != null ? other.pattern : this.pattern, other.page != null ? other.page : this.page,
 				other.pageSize != null ? other.pageSize : this.pageSize,
 				other.branch != null ? other.branch : this.branch, other.excludeArchived || this.excludeArchived);
 	}
@@ -153,6 +176,35 @@ public record EventFilter(@Nullable Instant from, @Nullable Instant to, @Nullabl
 	 */
 	public static EventFilter keywordSearch(String keyword, int page, int pageSize) {
 		return builder().keyword(keyword).page(page).pageSize(pageSize).build();
+	}
+
+	/**
+	 * Returns the first page of events whose message text contains, depending on
+	 * {@code matchMode}, any or all of {@code terms} (case-insensitive substring match
+	 * per term). Uses {@link #DEFAULT_PAGE_SIZE}.
+	 */
+	public static EventFilter keywordsSearch(List<String> terms, MatchMode matchMode) {
+		return builder().keywords(terms).matchMode(matchMode).page(0).pageSize(DEFAULT_PAGE_SIZE).build();
+	}
+
+	/**
+	 * Returns the first page of events whose message text matches the given regular
+	 * expression. Uses {@link #DEFAULT_PAGE_SIZE}. Case sensitivity is controlled by the
+	 * caller via {@link Pattern#CASE_INSENSITIVE} on the compiled {@code pattern}.
+	 *
+	 * <p>
+	 * <strong>Security:</strong> {@code pattern} must be a {@link Pattern} the calling
+	 * <em>code</em> compiled from a fixed or developer-authored expression. Never call
+	 * {@link Pattern#compile(String)} on a string sourced from a user, an LLM tool-call
+	 * argument, or any other untrusted input and pass the result here (or to
+	 * {@link Builder#pattern(Pattern)}) — an attacker-chosen regular expression can exhibit
+	 * catastrophic backtracking (ReDoS) when evaluated against attacker-influenced message
+	 * text such as {@link SessionEvent} content, causing denial of service. This type
+	 * intentionally has no {@code @Tool}-annotated entry point that accepts a raw regex
+	 * string for exactly this reason — keep it that way.
+	 */
+	public static EventFilter patternSearch(Pattern pattern) {
+		return builder().pattern(pattern).page(0).pageSize(DEFAULT_PAGE_SIZE).build();
 	}
 
 	/**
@@ -211,6 +263,24 @@ public record EventFilter(@Nullable Instant from, @Nullable Instant to, @Nullabl
 				return false;
 			}
 		}
+		if (this.keywords != null) {
+			String text = event.getMessage().getText();
+			if (text == null) {
+				return false;
+			}
+			String lowerText = text.toLowerCase();
+			boolean matched = (this.matchMode == MatchMode.ALL) ? this.keywords.stream().allMatch(lowerText::contains)
+					: this.keywords.stream().anyMatch(lowerText::contains);
+			if (!matched) {
+				return false;
+			}
+		}
+		if (this.pattern != null) {
+			String text = event.getMessage().getText();
+			if (text == null || !this.pattern.matcher(text).find()) {
+				return false;
+			}
+		}
 		if (this.branch != null) {
 			String eventBranch = event.getBranch();
 			if (eventBranch != null) {
@@ -247,6 +317,12 @@ public record EventFilter(@Nullable Instant from, @Nullable Instant to, @Nullabl
 		private @Nullable Integer lastN;
 
 		private @Nullable String keyword;
+
+		private @Nullable List<String> keywords;
+
+		private @Nullable MatchMode matchMode;
+
+		private @Nullable Pattern pattern;
 
 		private @Nullable Integer page;
 
@@ -307,6 +383,41 @@ public record EventFilter(@Nullable Instant from, @Nullable Instant to, @Nullabl
 		}
 
 		/**
+		 * Case-insensitive terms to match against {@code message.getText()}, combined
+		 * according to {@link #matchMode(MatchMode)} (default {@link MatchMode#ANY} if
+		 * left unset while {@code keywords} is set).
+		 */
+		public Builder keywords(@Nullable List<String> keywords) {
+			this.keywords = keywords;
+			return this;
+		}
+
+		/**
+		 * How {@link #keywords(List)} combine — {@link MatchMode#ANY} (at least one term
+		 * present) or {@link MatchMode#ALL} (every term present). Ignored unless
+		 * {@code keywords} is also set.
+		 */
+		public Builder matchMode(@Nullable MatchMode matchMode) {
+			this.matchMode = matchMode;
+			return this;
+		}
+
+		/**
+		 * A compiled regular expression evaluated against {@code message.getText()} via
+		 * {@link Pattern#matcher(CharSequence)}{@code .find()}. Events whose text is
+		 * {@code null} or does not match are excluded.
+		 *
+		 * <p>
+		 * <strong>Security:</strong> see the warning on {@link EventFilter#patternSearch(Pattern)}
+		 * — only pass a {@link Pattern} compiled from a fixed or developer-authored
+		 * expression, never one compiled from untrusted (e.g. LLM tool-call) input.
+		 */
+		public Builder pattern(@Nullable Pattern pattern) {
+			this.pattern = pattern;
+			return this;
+		}
+
+		/**
 		 * Zero-indexed page number for paginated results. Applied after per-event
 		 * filtering in chronological order (oldest first), so page 0 contains the oldest
 		 * matching events. Requires {@link #pageSize(Integer)} to be set.
@@ -346,7 +457,8 @@ public record EventFilter(@Nullable Instant from, @Nullable Instant to, @Nullabl
 		/** Constructs the {@link EventFilter}. */
 		public EventFilter build() {
 			return new EventFilter(this.from, this.to, this.messageTypes, this.excludeSynthetic, this.lastN,
-					this.keyword, this.page, this.pageSize, this.branch, this.excludeArchived);
+					this.keyword, this.keywords, this.matchMode, this.pattern, this.page, this.pageSize, this.branch,
+					this.excludeArchived);
 		}
 
 	}

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/tool/CrossSessionRecallTools.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/tool/CrossSessionRecallTools.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.tool;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.session.EventFilter;
+import org.springframework.ai.session.EventFilter.MatchMode;
+import org.springframework.ai.session.Session;
+import org.springframework.ai.session.SessionEvent;
+import org.springframework.ai.session.SessionService;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.util.json.JsonParser;
+import org.springframework.util.StringUtils;
+
+/**
+ * Cross-session Recall Storage for maintenance/analysis agents.
+ *
+ * <p>
+ * {@code SessionEventTools#conversationSearch} resolves exactly one session from the
+ * live request's {@code ToolContext} — the right scope for a conversational agent
+ * answering "what did we discuss earlier in <em>this</em> conversation." This class
+ * instead searches <strong>every session belonging to one user</strong>, which is what a
+ * background maintenance agent (e.g. Auto-Dream's Dreamer) needs to mine historical
+ * signal spanning many past conversations.
+ *
+ * <p>
+ * Unlike {@code conversation_search}, the target user is bound at construction time via
+ * {@link #builder(SessionService, String)} rather than accepted as a tool-call parameter
+ * — a misbehaving prompt cannot talk this tool into scanning a different user's sessions,
+ * because the model never gets to choose which user it searches.
+ *
+ * <p>
+ * Read-only: this class has no append/compact/delete capability.
+ *
+ * @author Christian Tzolov
+ * @since 2.0
+ */
+public class CrossSessionRecallTools {
+
+	private static final Logger logger = LoggerFactory.getLogger(CrossSessionRecallTools.class);
+
+	/**
+	 * Upper bound on the number of comma-separated terms accepted in {@code query}. Each
+	 * term becomes its own {@code LIKE} predicate (and, on a JDBC-backed
+	 * {@code SessionService}, its own bound SQL parameter) — without a cap, a very long
+	 * comma-separated {@code query} from a misbehaving or adversarial caller would grow
+	 * the generated query and parameter list without bound. Not a security boundary in
+	 * itself (every term is still safely bound, never concatenated into SQL text), just a
+	 * sanity limit on how large a single search request is allowed to be.
+	 */
+	static final int MAX_QUERY_TERMS = 20;
+
+	private final SessionService sessionService;
+
+	private final String userId;
+
+	private final int pageSize;
+
+	private CrossSessionRecallTools(SessionService sessionService, String userId, int pageSize) {
+		this.sessionService = sessionService;
+		this.userId = userId;
+		this.pageSize = pageSize;
+	}
+
+	/**
+	 * @param sessionService the session store to search
+	 * @param userId the user whose sessions this instance is scoped to — fixed for the
+	 * lifetime of the instance, never supplied by the model
+	 */
+	public static Builder builder(SessionService sessionService, String userId) {
+		return new Builder(sessionService, userId);
+	}
+
+	/**
+	 * Searches every session belonging to the configured user for events matching the
+	 * given criteria, aggregated and returned in chronological order across sessions.
+	 * @param innerThought agent's private reasoning (not returned to the caller)
+	 * @param query case-insensitive keyword, or comma-separated keywords
+	 * @param matchMode {@code "any"} (default) or {@code "all"} — how multiple
+	 * comma-separated keywords in {@code query} combine
+	 * @param since ISO-8601 instant; only events at or after this time are considered.
+	 * Omit to search the full history
+	 * @param page zero-indexed page of results; omit or pass {@code 0} for the first page
+	 * @return JSON array of matching events, or {@code "No results found."} if empty
+	 */
+	@Tool(name = "cross_session_search",
+			description = "Search across ALL of a user's sessions (not just the current one) for events matching "
+					+ "the given criteria. Intended for maintenance/analysis agents that need historical signal "
+					+ "spanning many past conversations, not for use by a live conversational agent (which should "
+					+ "prefer conversation_search). Returns paginated results ordered chronologically.")
+	public String crossSessionSearch(
+			@ToolParam(description = "Deep inner monologue private to you only.") String innerThought,
+			@ToolParam(
+					description = "Case-insensitive keyword to search for. Supply multiple, comma-separated keywords "
+							+ "to search for more than one term at once (up to 20 terms per call).") String query,
+			@ToolParam(description = "'any' (default) or 'all' — how multiple comma-separated keywords in 'query' "
+					+ "combine.", required = false) String matchMode,
+			@ToolParam(description = "ISO-8601 instant (e.g. '2026-07-01T00:00:00Z'); only events at or after this "
+					+ "time are considered. Omit to search the full history.", required = false) String since,
+			@ToolParam(description = "Page of results to retrieve (0-indexed). Omit or use 0 for the first page.",
+					required = false) Integer page) {
+
+		int pageNumber = (page != null) ? Math.max(0, page) : 0;
+
+		logger.debug("[cross_session_search] userId: {}, innerThought: {}, query: {}, matchMode: {}, since: {}, page: {}",
+				this.userId, innerThought, query, matchMode, since, pageNumber);
+
+		EventFilter filter = buildFilter(query, matchMode, since);
+
+		List<Session> sessions = this.sessionService.findByUserId(this.userId);
+
+		List<SessionEvent> allMatches = new ArrayList<>();
+		for (Session session : sessions) {
+			for (SessionEvent event : this.sessionService.getEvents(session.id(), filter)) {
+				if (StringUtils.hasText(event.getMessage().getText())) {
+					allMatches.add(event);
+				}
+			}
+		}
+
+		// Sort by the actual Instant, not its String rendering. Instant.toString()
+		// omits the fractional-seconds component when it is exactly zero but includes it
+		// otherwise, so two rendered timestamps of different lengths do not reliably
+		// compare in chronological order (e.g. "...:00.001Z" < "...:00Z" lexicographically,
+		// even though the former instant is later).
+		allMatches.sort(Comparator.comparing(SessionEvent::getTimestamp));
+
+		// Cast to long before multiplying so a large `page` cannot silently overflow int
+		// arithmetic and produce a negative index — mirrors the same guard already used
+		// for the SQL OFFSET parameter in JdbcSessionRepository.findEvents.
+		long fromIndexLong = (long) pageNumber * this.pageSize;
+		int fromIndex = (int) Math.min(fromIndexLong, allMatches.size());
+		int toIndex = (int) Math.min(fromIndexLong + this.pageSize, allMatches.size());
+		List<SessionEvent> pageResults = allMatches.subList(fromIndex, toIndex);
+
+		if (pageResults.isEmpty()) {
+			return "No results found.";
+		}
+
+		List<Map<String, String>> jsonResults = pageResults.stream()
+			.map(event -> Map.of("sessionId", event.getSessionId(), "timestamp", event.getTimestamp().toString(),
+					"type", event.getMessageType().getValue(), "text", event.getMessage().getText()))
+			.toList();
+
+		return JsonParser.toJson(jsonResults);
+	}
+
+	private EventFilter buildFilter(String query, String matchMode, String since) {
+		EventFilter.Builder builder = EventFilter.builder();
+
+		if (StringUtils.hasText(query)) {
+			List<String> terms = List.of(query.split(","))
+				.stream()
+				.map(String::trim)
+				.filter(StringUtils::hasText)
+				.toList();
+			if (terms.isEmpty()) {
+				// e.g. query = "," or ", " — has visible characters so it isn't blank,
+				// but splits into zero usable terms. Silently falling through to "no
+				// keyword filter" would turn a narrow search into "return everything for
+				// this user", so reject it explicitly instead.
+				throw new IllegalArgumentException(
+						"query '" + query + "' contained no usable search terms after splitting on ','");
+			}
+			if (terms.size() > MAX_QUERY_TERMS) {
+				throw new IllegalArgumentException("query supplied " + terms.size() + " comma-separated terms, "
+						+ "exceeding the maximum of " + MAX_QUERY_TERMS + " — narrow the search instead of "
+						+ "combining many terms into a single call");
+			}
+			if (terms.size() > 1) {
+				MatchMode mode = "all".equalsIgnoreCase(matchMode) ? MatchMode.ALL : MatchMode.ANY;
+				builder.keywords(terms).matchMode(mode);
+			}
+			else {
+				builder.keyword(terms.get(0));
+			}
+		}
+
+		if (StringUtils.hasText(since)) {
+			try {
+				builder.from(Instant.parse(since));
+			}
+			catch (DateTimeParseException ex) {
+				throw new IllegalArgumentException(
+						"since '" + since + "' is not a valid ISO-8601 instant (e.g. '2026-07-01T00:00:00Z')", ex);
+			}
+		}
+
+		return builder.build();
+	}
+
+	public static final class Builder {
+
+		private final SessionService sessionService;
+
+		private final String userId;
+
+		private int pageSize = EventFilter.DEFAULT_PAGE_SIZE;
+
+		private Builder(SessionService sessionService, String userId) {
+			if (sessionService == null) {
+				throw new IllegalArgumentException("sessionService must not be null");
+			}
+			if (!StringUtils.hasText(userId)) {
+				throw new IllegalArgumentException("userId must not be empty");
+			}
+			this.sessionService = sessionService;
+			this.userId = userId;
+		}
+
+		/**
+		 * Number of results returned per page by {@code cross_session_search}. Defaults
+		 * to {@link EventFilter#DEFAULT_PAGE_SIZE}.
+		 */
+		public Builder pageSize(int pageSize) {
+			if (pageSize <= 0) {
+				throw new IllegalArgumentException("pageSize must be positive");
+			}
+			this.pageSize = pageSize;
+			return this;
+		}
+
+		public CrossSessionRecallTools build() {
+			return new CrossSessionRecallTools(this.sessionService, this.userId, this.pageSize);
+		}
+
+	}
+
+}

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/EventFilterKeywordsAndPatternTests.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/EventFilterKeywordsAndPatternTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.session.EventFilter.MatchMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the grep-like {@code keywords}/{@code matchMode}/{@code pattern} matching
+ * added to {@link EventFilter}.
+ */
+class EventFilterKeywordsAndPatternTests {
+
+	private static final String SESSION_ID = "test-session";
+
+	private SessionEvent eventWithText(String text) {
+		return SessionEvent.builder().sessionId(SESSION_ID).message(new UserMessage(text)).build();
+	}
+
+	// --- keywords() / matchMode() ---
+
+	@Test
+	void anyModeMatchesWhenAtLeastOneTermPresent() {
+		EventFilter filter = EventFilter.keywordsSearch(List.of("actually", "instead"), MatchMode.ANY);
+
+		assertThat(filter.matches(eventWithText("I meant instead of that"))).isTrue();
+		assertThat(filter.matches(eventWithText("no relation here"))).isFalse();
+	}
+
+	@Test
+	void allModeRequiresEveryTerm() {
+		EventFilter filter = EventFilter.keywordsSearch(List.of("actually", "instead"), MatchMode.ALL);
+
+		assertThat(filter.matches(eventWithText("actually, use this instead"))).isTrue();
+		assertThat(filter.matches(eventWithText("actually, that's fine"))).isFalse();
+	}
+
+	@Test
+	void matchModeDefaultsToAnyWhenUnset() {
+		EventFilter filter = EventFilter.builder().keywords(List.of("spring", "boot")).build();
+
+		assertThat(filter.matchMode()).isEqualTo(MatchMode.ANY);
+	}
+
+	@Test
+	void keywordsMatchingIsCaseInsensitive() {
+		EventFilter filter = EventFilter.keywordsSearch(List.of("SPRING"), MatchMode.ANY);
+
+		assertThat(filter.matches(eventWithText("spring ai is great"))).isTrue();
+	}
+
+	@Test
+	void keywordsReturnsFalseWhenTextIsNull() {
+		EventFilter filter = EventFilter.keywordsSearch(List.of("anything"), MatchMode.ANY);
+
+		assertThat(filter.matches(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("")).build()))
+			.isFalse();
+	}
+
+	@Test
+	void emptyKeywordsListIsTreatedAsNoFilter() {
+		EventFilter filter = EventFilter.builder().keywords(List.of()).build();
+
+		assertThat(filter.keywords()).isNull();
+		assertThat(filter.matchMode()).isNull();
+		assertThat(filter.matches(eventWithText("anything at all"))).isTrue();
+	}
+
+	@Test
+	void blankTermsAreFilteredOut() {
+		EventFilter filter = EventFilter.builder().keywords(List.of("spring", "  ", "")).build();
+
+		assertThat(filter.keywords()).containsExactly("spring");
+	}
+
+	// --- pattern() ---
+
+	@Test
+	void patternMatchesRegex() {
+		EventFilter filter = EventFilter.patternSearch(Pattern.compile("\\bwe decided\\b"));
+
+		assertThat(filter.matches(eventWithText("we decided to go with option B"))).isTrue();
+		assertThat(filter.matches(eventWithText("we haven't decided yet"))).isFalse();
+	}
+
+	@Test
+	void patternRespectsCaseInsensitiveFlagWhenSet() {
+		EventFilter filter = EventFilter.patternSearch(Pattern.compile("remember that", Pattern.CASE_INSENSITIVE));
+
+		assertThat(filter.matches(eventWithText("Remember That the API key rotates monthly"))).isTrue();
+	}
+
+	@Test
+	void patternIsCaseSensitiveByDefault() {
+		EventFilter filter = EventFilter.patternSearch(Pattern.compile("Remember"));
+
+		assertThat(filter.matches(eventWithText("remember this"))).isFalse();
+		assertThat(filter.matches(eventWithText("Remember this"))).isTrue();
+	}
+
+	@Test
+	void patternReturnsFalseWhenTextIsEmpty() {
+		EventFilter filter = EventFilter.patternSearch(Pattern.compile(".+"));
+
+		assertThat(filter.matches(SessionEvent.builder().sessionId(SESSION_ID).message(new AssistantMessage("")).build()))
+			.isFalse();
+	}
+
+	// --- composition: keywords/keyword/pattern all AND together ---
+
+	@Test
+	void keywordAndPatternBothMustMatchWhenBothSet() {
+		EventFilter filter = EventFilter.builder().keyword("decided").pattern(Pattern.compile("option [A-Z]")).build();
+
+		assertThat(filter.matches(eventWithText("we decided on option B"))).isTrue();
+		assertThat(filter.matches(eventWithText("we decided nothing"))).isFalse();
+		assertThat(filter.matches(eventWithText("option B is available"))).isFalse();
+	}
+
+}

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/EventFilterMergeTests.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/EventFilterMergeTests.java
@@ -17,11 +17,14 @@
 package org.springframework.ai.session;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.session.EventFilter.MatchMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,6 +83,23 @@ class EventFilterMergeTests {
 		EventFilter base = EventFilter.builder().keyword("spring").pageSize(5).build();
 		EventFilter other = EventFilter.builder().keyword("ai").pageSize(5).build();
 		assertThat(base.merge(other).keyword()).isEqualTo("ai");
+	}
+
+	@Test
+	void otherKeywordsAndMatchModeOverrideBase() {
+		EventFilter base = EventFilter.keywordsSearch(List.of("spring"), MatchMode.ANY);
+		EventFilter other = EventFilter.keywordsSearch(List.of("actually", "instead"), MatchMode.ALL);
+		EventFilter merged = base.merge(other);
+		assertThat(merged.keywords()).containsExactly("actually", "instead");
+		assertThat(merged.matchMode()).isEqualTo(MatchMode.ALL);
+	}
+
+	@Test
+	void otherPatternOverridesBase() {
+		EventFilter base = EventFilter.patternSearch(Pattern.compile("we decided"));
+		EventFilter other = EventFilter.patternSearch(Pattern.compile("let's go with"));
+		EventFilter merged = base.merge(other);
+		assertThat(merged.pattern().pattern()).isEqualTo("let's go with");
 	}
 
 	@Test

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/tool/CrossSessionRecallToolsTests.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/tool/CrossSessionRecallToolsTests.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.tool;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.session.CreateSessionRequest;
+import org.springframework.ai.session.DefaultSessionService;
+import org.springframework.ai.session.InMemorySessionRepository;
+import org.springframework.ai.session.Session;
+import org.springframework.ai.session.SessionEvent;
+import org.springframework.ai.session.SessionService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link CrossSessionRecallTools#crossSessionSearch}.
+ */
+class CrossSessionRecallToolsTests {
+
+	private SessionService sessionService;
+
+	@BeforeEach
+	void setUp() {
+		this.sessionService = DefaultSessionService.builder()
+			.sessionRepository(InMemorySessionRepository.builder().build())
+			.build();
+	}
+
+	private CrossSessionRecallTools toolsFor(String userId) {
+		return CrossSessionRecallTools.builder(this.sessionService, userId).build();
+	}
+
+	@Test
+	void returnsNoResultsWhenUserHasNoSessions() {
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "anything", null, null, 0);
+		assertThat(result).isEqualTo("No results found.");
+	}
+
+	@Test
+	void findsMatchesAcrossMultipleSessions() {
+		Session session1 = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		Session session2 = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+
+		this.sessionService.appendMessage(session1.id(), new UserMessage("Tell me about Spring AI"));
+		this.sessionService.appendMessage(session2.id(), new UserMessage("What about LangChain?"));
+		this.sessionService.appendMessage(session2.id(), new AssistantMessage("Spring AI is a Java framework."));
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "spring", null, null, 0);
+
+		assertThat(result).contains("Tell me about Spring AI").contains("Spring AI is a Java framework.");
+		assertThat(result).doesNotContain("LangChain");
+	}
+
+	@Test
+	void resultsIncludeSessionIdAcrossSessions() {
+		Session session1 = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		this.sessionService.appendMessage(session1.id(), new UserMessage("Spring AI memory management"));
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "memory", null, null, 0);
+
+		assertThat(result).contains("sessionId").contains(session1.id());
+	}
+
+	@Test
+	void onlySearchesSessionsForTheConfiguredUser() {
+		Session aliceSession = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		Session bobSession = this.sessionService.create(CreateSessionRequest.builder().userId("bob").build());
+
+		this.sessionService.appendMessage(aliceSession.id(), new UserMessage("alice secret note"));
+		this.sessionService.appendMessage(bobSession.id(), new UserMessage("bob secret note"));
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "secret", null, null, 0);
+
+		assertThat(result).contains("alice secret note").doesNotContain("bob secret note");
+	}
+
+	@Test
+	void multipleCommaSeparatedKeywordsDefaultToAnyMatch() {
+		Session session = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		this.sessionService.appendMessage(session.id(), new UserMessage("we decided to ship it"));
+		this.sessionService.appendMessage(session.id(), new UserMessage("let's go with option B"));
+		this.sessionService.appendMessage(session.id(), new UserMessage("unrelated message"));
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "we decided, let's go with", null, null,
+				0);
+
+		assertThat(result).contains("we decided to ship it").contains("let's go with option B");
+		assertThat(result).doesNotContain("unrelated message");
+	}
+
+	@Test
+	void allMatchModeRequiresEveryKeyword() {
+		Session session = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		this.sessionService.appendMessage(session.id(), new UserMessage("actually, let's use this instead"));
+		this.sessionService.appendMessage(session.id(), new UserMessage("actually that's fine as-is"));
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "actually, instead", "all", null, 0);
+
+		assertThat(result).contains("actually, let's use this instead");
+		assertThat(result).doesNotContain("actually that's fine as-is");
+	}
+
+	@Test
+	void sinceExcludesEventsBeforeTheGivenInstant() {
+		Session session = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		this.sessionService.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.timestamp(Instant.parse("2026-01-01T00:00:00Z"))
+			.message(new UserMessage("old spring note"))
+			.build());
+		this.sessionService.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.timestamp(Instant.parse("2026-07-01T00:00:00Z"))
+			.message(new UserMessage("recent spring note"))
+			.build());
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "spring", null, "2026-06-01T00:00:00Z", 0);
+
+		assertThat(result).contains("recent spring note").doesNotContain("old spring note");
+	}
+
+	@Test
+	void malformedSinceThrowsIllegalArgumentExceptionInsteadOfRawParseException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(
+					() -> toolsFor("alice").crossSessionSearch("thinking...", "spring", null, "2026-07-01", 0))
+			.withMessageContaining("2026-07-01");
+	}
+
+	@Test
+	void commaOnlyQueryThrowsInsteadOfSilentlySearchingEverything() {
+		Session session = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		this.sessionService.appendMessage(session.id(), new UserMessage("this should never be returned"));
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> toolsFor("alice").crossSessionSearch("thinking...", ",", null, null, 0));
+	}
+
+	@Test
+	void queryWithinTermLimitIsAccepted() {
+		Session session = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		this.sessionService.appendMessage(session.id(), new UserMessage("term9 present"));
+
+		String query = String.join(",", java.util.stream.IntStream.rangeClosed(1, CrossSessionRecallTools.MAX_QUERY_TERMS)
+			.mapToObj(i -> "term" + i)
+			.toList());
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", query, null, null, 0);
+
+		assertThat(result).contains("term9 present");
+	}
+
+	@Test
+	void queryExceedingTermLimitThrows() {
+		String query = String.join(",",
+				java.util.stream.IntStream.rangeClosed(1, CrossSessionRecallTools.MAX_QUERY_TERMS + 1)
+					.mapToObj(i -> "term" + i)
+					.toList());
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> toolsFor("alice").crossSessionSearch("thinking...", query, null, null, 0))
+			.withMessageContaining(String.valueOf(CrossSessionRecallTools.MAX_QUERY_TERMS));
+	}
+
+	@Test
+	void resultsAreOrderedByActualInstantNotStringRendering() {
+		// Instant.toString() omits fractional seconds when exactly zero, so a naive
+		// String-lexicographic sort would place "afterExactSecond" before
+		// "beforeExactSecond" even though it is chronologically later.
+		Session session = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		Instant exactSecond = Instant.parse("2026-01-01T00:00:00Z");
+
+		this.sessionService.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.timestamp(exactSecond.minusMillis(1))
+			.message(new UserMessage("marker beforeExactSecond"))
+			.build());
+		this.sessionService.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.timestamp(exactSecond)
+			.message(new UserMessage("marker onExactSecond"))
+			.build());
+		this.sessionService.appendEvent(SessionEvent.builder()
+			.sessionId(session.id())
+			.timestamp(exactSecond.plusMillis(1))
+			.message(new UserMessage("marker afterExactSecond"))
+			.build());
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "marker", null, null, 0);
+
+		int before = result.indexOf("beforeExactSecond");
+		int on = result.indexOf("onExactSecond");
+		int after = result.indexOf("afterExactSecond");
+		assertThat(before).isPositive();
+		assertThat(before).isLessThan(on);
+		assertThat(on).isLessThan(after);
+	}
+
+	@Test
+	void veryLargePageNumberReturnsNoResultsInsteadOfOverflowing() {
+		Session session = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		this.sessionService.appendMessage(session.id(), new UserMessage("entry 1"));
+
+		String result = toolsFor("alice").crossSessionSearch("thinking...", "entry", null, null, Integer.MAX_VALUE);
+
+		assertThat(result).isEqualTo("No results found.");
+	}
+
+	@Test
+	void paginationSplitsAggregatedResultsAcrossSessions() {
+		Session session1 = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+		Session session2 = this.sessionService.create(CreateSessionRequest.builder().userId("alice").build());
+
+		for (int i = 1; i <= 6; i++) {
+			this.sessionService.appendMessage(session1.id(), new UserMessage("entry " + i));
+		}
+		for (int i = 7; i <= 12; i++) {
+			this.sessionService.appendMessage(session2.id(), new UserMessage("entry " + i));
+		}
+
+		CrossSessionRecallTools tools = CrossSessionRecallTools.builder(this.sessionService, "alice").pageSize(10).build();
+
+		String page0 = tools.crossSessionSearch("thinking...", "entry", null, null, 0);
+		String page1 = tools.crossSessionSearch("thinking...", "entry", null, null, 1);
+
+		assertThat(page0).contains("entry 1").doesNotContain("entry 11");
+		assertThat(page1).contains("entry 11");
+	}
+
+	@Test
+	void builderRejectsNullSessionService() {
+		assertThatIllegalArgumentException().isThrownBy(() -> CrossSessionRecallTools.builder(null, "alice"));
+	}
+
+	@Test
+	void builderRejectsEmptyUserId() {
+		assertThatIllegalArgumentException().isThrownBy(() -> CrossSessionRecallTools.builder(this.sessionService, ""));
+	}
+
+}


### PR DESCRIPTION
- Extends EventFilter with multi-term (keywords/matchMode) and regex (pattern) matching, pushed down to SQL for JDBC-backed repositories with an in-memory fallback for pattern.
- Adds CrossSessionRecallTools, a cross_session_search tool for background/maintenance agents scoped to all of a user's sessions.
- Update reference docs