### PR TITLE
Make appendEvent idempotent via pluggable event id generators

### DIFF
--- a/docs/session-management/chat-client.md
+++ b/docs/session-management/chat-client.md
@@ -80,6 +80,29 @@ ChatClient client = ChatClient.builder(chatModel)
 
 ---
 
+## Idempotent session-event ids {#idempotent-session-event-ids}
+
+By default every persisted event gets a random id, so a retried write always creates a
+new event. Configure `requestEventIdGenerator`/`responseEventIdGenerator` to derive a
+deterministic id instead — a retry with the same id becomes a no-op (see [Idempotent
+`appendEvent`](concepts.md)):
+
+```java
+IdempotentSessionEventIdGenerator idGenerator = new IdempotentSessionEventIdGenerator();
+
+SessionMemoryAdvisor advisor = SessionMemoryAdvisor.builder(sessionService)
+    .requestEventIdGenerator(idGenerator)
+    .responseEventIdGenerator(idGenerator)
+    .build();
+```
+
+`IdempotentSessionEventIdGenerator` reuses the model's own tool-call/tool-response ids
+where present, otherwise hashes a configurable context-key fingerprint (session id by
+default). Pass additional keys — e.g. a per-request run id — to scope ids more tightly,
+so retries still dedupe but distinct calls with identical content don't collide.
+
+---
+
 ## Passing a session ID per request
 
 Pass a session ID at call time via the advisor context:

--- a/docs/session-management/concepts.md
+++ b/docs/session-management/concepts.md
@@ -209,6 +209,15 @@ CAS returns `false` — the caller treats this as a no-op rather than retrying. 
 implementations (JDBC, Redis) should map this to a database-level optimistic-lock column
 or a Redis `WATCH`.
 
+**Idempotent `appendEvent`**
+
+A retried `appendEvent` call for an id that was already committed is a no-op, not an
+error or a duplicate — both `InMemorySessionRepository` and `JdbcSessionRepository`
+check by `SessionEvent.getId()` (the table's primary key in the JDBC case) before
+writing. The default id is still a random UUID, so this only applies when a caller
+supplies its own deterministic id — see [`SessionMemoryAdvisor`'s pluggable id
+generators](chat-client.md#idempotent-session-event-ids).
+
 **Event ordering**
 
 Events are returned in insertion (logical conversation) order, not by wall-clock

--- a/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
+++ b/spring-ai-session-jdbc/src/main/java/org/springframework/ai/session/jdbc/JdbcSessionRepository.java
@@ -45,6 +45,7 @@ import org.springframework.ai.session.EventFilter;
 import org.springframework.ai.session.Session;
 import org.springframework.ai.session.SessionEvent;
 import org.springframework.ai.session.SessionRepository;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
@@ -83,6 +84,13 @@ import org.springframework.util.Assert;
  * every {@link #appendEvent} and {@link #compactEvents} call. {@code compactEvents} guards
  * compaction by issuing a conditional {@code UPDATE … WHERE event_version = ?} first; if
  * zero rows are updated the swap is abandoned and {@code false} is returned.
+ *
+ * <h2>Idempotent append</h2>
+ * <p>
+ * {@code AI_SESSION_EVENT.id} is the table's primary key, so {@link #appendEvent} relies
+ * on the resulting unique-constraint violation (translated by Spring JDBC to
+ * {@link org.springframework.dao.DuplicateKeyException}) to detect a retried append of an
+ * event whose id was already committed, and treats it as a no-op instead of propagating.
  *
  * <h2>Event ordering</h2>
  * <p>
@@ -217,11 +225,22 @@ public final class JdbcSessionRepository implements SessionRepository {
 		Assert.notNull(event, "event must not be null");
 		String sessionId = event.getSessionId();
 		requireSessionExists(sessionId);
-		this.transactionTemplate.execute(status -> {
-			insertEvent(event);
-			this.jdbcTemplate.update(INCREMENT_EVENT_VERSION, sessionId);
-			return null;
-		});
+		try {
+			this.transactionTemplate.execute(status -> {
+				insertEvent(event);
+				this.jdbcTemplate.update(INCREMENT_EVENT_VERSION, sessionId);
+				return null;
+			});
+		}
+		catch (DuplicateKeyException ex) {
+			// Idempotent replay: an event with this id (SessionEvent#getId()) was
+			// already committed, e.g. a retried append after a crash between the insert
+			// and the caller receiving confirmation. Treat as a no-op rather than
+			// propagating -- the transaction above has already rolled back, so neither
+			// the insert nor the version increment took effect twice.
+			logger.debug("appendEvent: event {} already exists for session {}; treating as an idempotent replay",
+					event.getId(), sessionId);
+		}
 	}
 
 	@Override

--- a/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
+++ b/spring-ai-session-jdbc/src/test/java/org/springframework/ai/session/jdbc/JdbcSessionRepositoryTests.java
@@ -187,6 +187,37 @@ class JdbcSessionRepositoryTests {
 	}
 
 	@Test
+	void appendEventWithSameIdIsIdempotent() {
+		Session session = buildSession("user-1");
+		this.repository.save(session);
+		SessionEvent event = SessionEvent.builder()
+			.id("deterministic-event-id")
+			.sessionId(session.id())
+			.message(new UserMessage("hi"))
+			.build();
+
+		this.repository.appendEvent(event);
+		long versionAfterFirst = this.repository.getEventVersion(session.id());
+		this.repository.appendEvent(event);
+		long versionAfterReplay = this.repository.getEventVersion(session.id());
+
+		assertThat(this.repository.findEvents(session.id(), EventFilter.all())).hasSize(1);
+		assertThat(versionAfterReplay).isEqualTo(versionAfterFirst);
+	}
+
+	@Test
+	void appendEventWithDifferentIdIsNotTreatedAsDuplicate() {
+		Session session = buildSession("user-1");
+		this.repository.save(session);
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("first")).build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("second")).build());
+
+		assertThat(this.repository.findEvents(session.id(), EventFilter.all())).hasSize(2);
+	}
+
+	@Test
 	void appendedEventsAreReturnedInChronologicalOrder() {
 		Session session = buildSession("user-order");
 		this.repository.save(session);

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/InMemorySessionRepository.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/InMemorySessionRepository.java
@@ -106,6 +106,13 @@ public final class InMemorySessionRepository implements SessionRepository {
 			if (existing == null) {
 				throw new IllegalArgumentException("Session not found: " + sessionId);
 			}
+			boolean alreadyAppended = existing.events().stream().anyMatch(e -> e.getId().equals(event.getId()));
+			if (alreadyAppended) {
+				// Idempotent replay: an event with this id was already committed, e.g. a
+				// retried append after a crash. No-op -- do not duplicate the event or
+				// increment the version.
+				return existing;
+			}
 			List<SessionEvent> newEvents = new ArrayList<>(existing.events());
 			newEvents.add(event);
 			return existing.withEvents(newEvents);

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/SessionRepository.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/SessionRepository.java
@@ -62,6 +62,14 @@ public interface SessionRepository {
 	 * Appends a single event to the session's event log. The target session is identified
 	 * by {@link SessionEvent#getSessionId()}. Also updates {@code lastActiveAt} on the
 	 * session.
+	 * <p>
+	 * <strong>Idempotent by id:</strong> if an event with the same
+	 * {@link SessionEvent#getId()} already exists for this session, this call is a no-op
+	 * — it does not throw, and it does not append a duplicate row or increment the
+	 * event-log version. This makes a retried append (e.g. after a crash between the
+	 * write and the caller receiving confirmation) safe to repeat. Callers that want this
+	 * safety should supply a deterministic id (e.g. derived from a durable run/turn id)
+	 * rather than relying on {@link SessionEvent.Builder}'s random default.
 	 * @throws IllegalArgumentException if the session does not exist
 	 */
 	void appendEvent(SessionEvent event);
@@ -103,8 +111,10 @@ public interface SessionRepository {
 
 	/**
 	 * Returns the current event-log version for the given session. The version is
-	 * incremented atomically on every {@link #appendEvent} and {@link #compactEvents}
-	 * call. Returns {@code 0} when the session does not exist or has no events yet.
+	 * incremented atomically on every {@link #appendEvent} call that actually appends a
+	 * new event, and on every {@link #compactEvents} call (an idempotent replay of an
+	 * already-applied {@link #appendEvent} does not increment it). Returns {@code 0} when
+	 * the session does not exist or has no events yet.
 	 * <p>
 	 * Read this <em>before</em> calling {@link #findEvents} to obtain a version that is
 	 * guaranteed to be ≤ the version of the events you subsequently read, which is the

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/IdempotentSessionEventIdGenerator.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/IdempotentSessionEventIdGenerator.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.advisor;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+
+/**
+ * A deterministic, chain-shape-agnostic {@link SessionEventRequestIdGenerator}/
+ * {@link SessionEventResponseIdGenerator} that makes retried
+ * {@code SessionMemoryAdvisor} writes idempotent instead of a fresh random id every
+ * call. Implements both generator interfaces via overloaded {@code generate} methods,
+ * sharing one hybrid derivation:
+ *
+ * <ul>
+ * <li>For a tool-call/tool-response message, reuse the model's own
+ * {@code ToolCall}/{@code ToolResponse} ids -- already globally unique per model turn,
+ * and the natural idempotency key for any tool-calling durability layer sitting
+ * elsewhere in the same application, so both stay consistent on the same identity.
+ * <li>Otherwise (plain user/system/assistant-text messages), fall back to a SHA-256
+ * content hash.
+ * </ul>
+ * Both are prefixed with a context key/value fingerprint -- see below -- so the same
+ * fallback and prefixing logic applies uniformly to every message type; prefixing more
+ * distinguishing context never causes a false collision, it can only add uniqueness.
+ *
+ * <p>
+ * This needs no run id, no loop-iteration counter, and no cooperation from whichever
+ * advisor(s) happen to wrap {@code SessionMemoryAdvisor} -- it stays correct however many
+ * times the advisor runs per call (e.g. nested inside a {@code ToolCallingAdvisor} loop,
+ * or any other recursive advisor).
+ *
+ * <p>
+ * <strong>Context key fingerprint:</strong> ids are derived from the values of a
+ * configurable list of context keys (read from {@link ChatClientRequest#context()} /
+ * {@link ChatClientResponse#context()}), joined in the order given. The no-arg
+ * constructor defaults to {@code [SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY]} --
+ * session-scoped ids, matching what a plain {@code SessionMemoryAdvisor} would log.
+ * {@link #IdempotentSessionEventIdGenerator(String...)} takes the *complete* key list
+ * instead of appending to that default, so a caller who also wants session-scoping
+ * alongside another key must list {@code SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY}
+ * explicitly, e.g. if the application also assigns a durable per-request run id
+ * (context key conventionally named {@code "run-id"} or similar):
+ * {@code new IdempotentSessionEventIdGenerator("run-id", SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY)}.
+ * Folding in a run id makes ids retry-scoped rather than only session-scoped: a genuine
+ * retry (same run id, same content) still dedupes, but two distinct calls that happen to
+ * share identical content no longer collide just because they share a session.
+ *
+ * <p>
+ * Known limitation of the content-hash fallback: two <em>legitimately</em> identical
+ * messages appended back-to-back within the same fingerprint (e.g. the user literally
+ * sends "hi" twice in the same run) collide and the second is dropped as an apparent
+ * replay -- add a key that varies per logical turn (or prefer the tool-id path) if that
+ * distinction matters.
+ *
+ * @author Christian Tzolov
+ * @since 0.7.0
+ */
+public final class IdempotentSessionEventIdGenerator implements SessionEventRequestIdGenerator, SessionEventResponseIdGenerator {
+
+	private final List<String> contextKeys;
+
+	/** Session-scoped ids only, equivalent to {@code (SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY)}. */
+	public IdempotentSessionEventIdGenerator() {
+		this(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY);
+	}
+
+	/**
+	 * @param contextKeys the complete, ordered list of context keys to fingerprint --
+	 * not appended to the no-arg default, so include
+	 * {@code SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY} explicitly if session-scoping
+	 * is still wanted alongside the other key(s).
+	 */
+	public IdempotentSessionEventIdGenerator(String... contextKeys) {
+		this.contextKeys = List.of(contextKeys);
+	}
+
+	@Override
+	public String generate(ChatClientRequest request, Message message) {
+		return deriveEventId(contextFingerprint(request.context()), message);
+	}
+
+	@Override
+	public String generate(ChatClientResponse response, Message message) {
+		return deriveEventId(contextFingerprint(response.context()), message);
+	}
+
+	private String contextFingerprint(Map<String, Object> context) {
+		return this.contextKeys.stream().map(key -> key + ":" + context.get(key)).collect(Collectors.joining(","));
+	}
+
+	private static String deriveEventId(String contextFingerprint, Message message) {
+		if (message instanceof AssistantMessage assistantMessage && !assistantMessage.getToolCalls().isEmpty()) {
+			String callIds = assistantMessage.getToolCalls()
+				.stream()
+				.map(AssistantMessage.ToolCall::id)
+				.collect(Collectors.joining(","));
+			return contextFingerprint + ":toolcall:" + callIds;
+		}
+		if (message instanceof ToolResponseMessage toolResponseMessage) {
+			String responseIds = toolResponseMessage.getResponses()
+				.stream()
+				.map(ToolResponseMessage.ToolResponse::id)
+				.collect(Collectors.joining(","));
+			return contextFingerprint + ":toolresp:" + responseIds;
+		}
+		String text = message.getText() == null ? "" : message.getText();
+		String hash = sha256Hex(contextFingerprint + ":" + message.getMessageType() + ":" + text);
+		return contextFingerprint + ":" + message.getMessageType() + ":" + hash;
+	}
+
+	private static String sha256Hex(String input) {
+		try {
+			byte[] digest = MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(digest);
+		}
+		catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("SHA-256 not available", ex);
+		}
+	}
+
+}

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionEventRequestIdGenerator.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionEventRequestIdGenerator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.advisor;
+
+import java.util.UUID;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.session.SessionEvent;
+
+/**
+ * Derives the {@link SessionEvent#getId()} used when {@link SessionMemoryAdvisor#before}
+ * persists the current user (or tool-response) message.
+ *
+ * <p>
+ * The default, {@link #random()}, reproduces the id-less behaviour
+ * {@code SessionService.appendMessage} always had before this SPI existed -- a fresh
+ * random id every call, so every append is a new event. Supplying a generator that
+ * derives a <em>deterministic</em> id for the same logical turn (e.g. content-addressable,
+ * or reusing an upstream durability layer's own idempotency key) makes a retried append
+ * an idempotent no-op instead of a duplicate, via
+ * {@code SessionRepository.appendEvent}'s id-based replay contract.
+ *
+ * @see SessionEventResponseIdGenerator the counterpart used in {@link SessionMemoryAdvisor#after}
+ */
+@FunctionalInterface
+public interface SessionEventRequestIdGenerator {
+
+	String generate(ChatClientRequest request, Message message);
+
+	static SessionEventRequestIdGenerator random() {
+		return (request, message) -> UUID.randomUUID().toString();
+	}
+
+}

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionEventResponseIdGenerator.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionEventResponseIdGenerator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.advisor;
+
+import java.util.UUID;
+
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.session.SessionEvent;
+
+/**
+ * Derives the {@link SessionEvent#getId()} used when {@link SessionMemoryAdvisor#after}
+ * persists an assistant reply message.
+ *
+ * <p>
+ * Separate from {@link SessionEventRequestIdGenerator} rather than one shared signature
+ * because {@code after(ChatClientResponse, AdvisorChain)} never receives the original
+ * {@code ChatClientRequest} -- that's {@code BaseAdvisor}'s contract, not something this
+ * SPI can paper over. Session id and any other context needed for a deterministic
+ * derivation are still available via {@link ChatClientResponse#context()}, which carries
+ * forward whatever the request's context held.
+ *
+ * <p>
+ * The default, {@link #random()}, reproduces the id-less behaviour
+ * {@code SessionService.appendMessage} always had before this SPI existed.
+ *
+ * @see SessionEventRequestIdGenerator the counterpart used in {@link SessionMemoryAdvisor#before}
+ */
+@FunctionalInterface
+public interface SessionEventResponseIdGenerator {
+
+	String generate(ChatClientResponse response, Message message);
+
+	static SessionEventResponseIdGenerator random() {
+		return (response, message) -> UUID.randomUUID().toString();
+	}
+
+}

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
@@ -77,6 +77,15 @@ import org.springframework.util.Assert;
  * so only the first writer succeeds; the second detects the version mismatch and skips
  * silently. No compaction result is lost or corrupted.
  *
+ * <p>
+ * <strong>Event id generation:</strong> by default every persisted event gets a fresh
+ * random id ({@link SessionEventRequestIdGenerator#random()} /
+ * {@link SessionEventResponseIdGenerator#random()}), so a retried append is always a new
+ * event. Configure {@link Builder#requestEventIdGenerator} / {@link Builder#responseEventIdGenerator}
+ * with a deterministic derivation (e.g. content-addressable, or reusing an upstream
+ * durability layer's own idempotency key) to make a retried append an idempotent no-op
+ * instead, via {@code SessionRepository.appendEvent}'s id-based replay contract.
+ *
  * @author Christian Tzolov
  * @since 2.0.0
  */
@@ -112,12 +121,17 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 
 	private final MessageFilter messageFilter;
 
+	private final SessionEventRequestIdGenerator requestEventIdGenerator;
+
+	private final SessionEventResponseIdGenerator responseEventIdGenerator;
+
 	@Nullable private final CompactionTrigger compactionTrigger;
 
 	@Nullable private final CompactionStrategy compactionStrategy;
 
 	private SessionMemoryAdvisor(SessionService sessionService, String defaultUserId, int order, Scheduler scheduler,
-			EventFilter eventFilter, MessageFilter messageFilter, @Nullable CompactionTrigger compactionTrigger,
+			EventFilter eventFilter, MessageFilter messageFilter, SessionEventRequestIdGenerator requestEventIdGenerator,
+			SessionEventResponseIdGenerator responseEventIdGenerator, @Nullable CompactionTrigger compactionTrigger,
 			@Nullable CompactionStrategy compactionStrategy) {
 		this.sessionService = sessionService;
 		this.defaultUserId = defaultUserId;
@@ -125,6 +139,8 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 		this.scheduler = scheduler;
 		this.eventFilter = eventFilter;
 		this.messageFilter = messageFilter;
+		this.requestEventIdGenerator = requestEventIdGenerator;
+		this.responseEventIdGenerator = responseEventIdGenerator;
 		this.compactionTrigger = compactionTrigger;
 		this.compactionStrategy = compactionStrategy;
 	}
@@ -205,7 +221,11 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 		// untouched.
 		Message userMessage = request.prompt().getLastUserOrToolResponseMessage();
 		if (userMessage != null && shouldPersist(userMessage, sessionId)) {
-			this.sessionService.appendMessage(sessionId, userMessage);
+			this.sessionService.appendEvent(SessionEvent.builder()
+				.id(this.requestEventIdGenerator.generate(request, userMessage))
+				.sessionId(sessionId)
+				.message(userMessage)
+				.build());
 		}
 
 		return request.mutate().prompt(request.prompt().mutate().messages(combined).build()).build();
@@ -224,7 +244,11 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 				.stream()
 				.map(g -> (Message) g.getOutput())
 				.filter(msg -> shouldPersist(msg, sessionId))
-				.forEach(msg -> this.sessionService.appendMessage(sessionId, msg));
+				.forEach(msg -> this.sessionService.appendEvent(SessionEvent.builder()
+					.id(this.responseEventIdGenerator.generate(response, msg))
+					.sessionId(sessionId)
+					.message(msg)
+					.build()));
 		}
 
 		// 2. Compact synchronously if configured — the full turn (user + assistant) is
@@ -300,6 +324,10 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 
 		private MessageFilter messageFilter = MessageFilter.skipEmptyMessages();
 
+		private SessionEventRequestIdGenerator requestEventIdGenerator = SessionEventRequestIdGenerator.random();
+
+		private SessionEventResponseIdGenerator responseEventIdGenerator = SessionEventResponseIdGenerator.random();
+
 		@Nullable private CompactionTrigger compactionTrigger;
 
 		@Nullable private CompactionStrategy compactionStrategy;
@@ -373,13 +401,38 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 			return this;
 		}
 
+		/**
+		 * Overrides how the id is derived for the session event persisted in
+		 * {@code before()} (the current user/tool-response message). Defaults to
+		 * {@link SessionEventRequestIdGenerator#random()} -- a fresh random id every
+		 * call, i.e. today's behaviour. Supply a deterministic generator to make a
+		 * retried append idempotent instead of a duplicate.
+		 */
+		public Builder requestEventIdGenerator(SessionEventRequestIdGenerator requestEventIdGenerator) {
+			Assert.notNull(requestEventIdGenerator, "requestEventIdGenerator must not be null");
+			this.requestEventIdGenerator = requestEventIdGenerator;
+			return this;
+		}
+
+		/**
+		 * Overrides how the id is derived for each session event persisted in
+		 * {@code after()} (the assistant reply message(s)). Defaults to
+		 * {@link SessionEventResponseIdGenerator#random()}.
+		 */
+		public Builder responseEventIdGenerator(SessionEventResponseIdGenerator responseEventIdGenerator) {
+			Assert.notNull(responseEventIdGenerator, "responseEventIdGenerator must not be null");
+			this.responseEventIdGenerator = responseEventIdGenerator;
+			return this;
+		}
+
 		public SessionMemoryAdvisor build() {
 			if ((this.compactionTrigger == null) != (this.compactionStrategy == null)) {
 				throw new IllegalArgumentException(
 						"compactionTrigger and compactionStrategy must be set together — set both or neither");
 			}
 			return new SessionMemoryAdvisor(this.sessionService, this.defaultUserId, this.order, this.scheduler,
-					this.eventFilter, this.messageFilter, this.compactionTrigger, this.compactionStrategy);
+					this.eventFilter, this.messageFilter, this.requestEventIdGenerator, this.responseEventIdGenerator,
+					this.compactionTrigger, this.compactionStrategy);
 		}
 
 	}

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/InMemorySessionRepositoryTests.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/InMemorySessionRepositoryTests.java
@@ -67,6 +67,35 @@ class InMemorySessionRepositoryTests {
 	}
 
 	@Test
+	void appendEventWithSameIdIsIdempotent() {
+		Session session = this.repository.save(buildSession("user-1"));
+		SessionEvent event = SessionEvent.builder()
+			.id("deterministic-event-id")
+			.sessionId(session.id())
+			.message(new UserMessage("hi"))
+			.build();
+
+		this.repository.appendEvent(event);
+		long versionAfterFirst = this.repository.getEventVersion(session.id());
+		this.repository.appendEvent(event);
+		long versionAfterReplay = this.repository.getEventVersion(session.id());
+
+		assertThat(this.repository.findEvents(session.id(), EventFilter.all())).hasSize(1);
+		assertThat(versionAfterReplay).isEqualTo(versionAfterFirst);
+	}
+
+	@Test
+	void appendEventWithDifferentIdIsNotTreatedAsDuplicate() {
+		Session session = this.repository.save(buildSession("user-1"));
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("first")).build());
+		this.repository.appendEvent(
+				SessionEvent.builder().sessionId(session.id()).message(new UserMessage("second")).build());
+
+		assertThat(this.repository.findEvents(session.id(), EventFilter.all())).hasSize(2);
+	}
+
+	@Test
 	void findEventsLastNReturnsOnlyLastNEvents() {
 		Session session = buildSession("user-2");
 		this.repository.save(session);

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/IdempotentSessionEventIdGeneratorTests.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/IdempotentSessionEventIdGeneratorTests.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.session.advisor;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.session.CreateSessionRequest;
+import org.springframework.ai.session.DefaultSessionService;
+import org.springframework.ai.session.EventFilter;
+import org.springframework.ai.session.InMemorySessionRepository;
+import org.springframework.ai.session.Session;
+import org.springframework.ai.session.SessionService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link IdempotentSessionEventIdGenerator}, exercised through a real
+ * {@link SessionMemoryAdvisor} + {@link InMemorySessionRepository} so the assertions
+ * cover the actual persisted event log, not just the derived id strings in isolation.
+ */
+class IdempotentSessionEventIdGeneratorTests {
+
+	private static final String RUN_ID_KEY = "run-id";
+
+	private SessionService sessionService;
+
+	private String sessionId;
+
+	@BeforeEach
+	void setUp() {
+		this.sessionService = DefaultSessionService.builder()
+			.sessionRepository(InMemorySessionRepository.builder().build())
+			.build();
+		Session session = this.sessionService.create(CreateSessionRequest.builder().userId("test-user").build());
+		this.sessionId = session.id();
+	}
+
+	@Test
+	void retriedCallWithSameContentDoesNotDuplicateSessionEvents() {
+		SessionMemoryAdvisor advisor = advisorWith(new IdempotentSessionEventIdGenerator());
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		advisor.before(buildRequest("hello"), chain);
+		advisor.after(buildResponse("the answer"), chain);
+		advisor.before(buildRequest("hello"), chain);
+		advisor.after(buildResponse("the answer"), chain);
+
+		assertThat(this.sessionService.getEvents(this.sessionId, EventFilter.all())).hasSize(2);
+	}
+
+	@Test
+	void turnsWithDifferentContentAreBothRecorded() {
+		SessionMemoryAdvisor advisor = advisorWith(new IdempotentSessionEventIdGenerator());
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		advisor.before(buildRequest("question one"), chain);
+		advisor.after(buildResponse("answer one"), chain);
+		advisor.before(buildRequest("question two"), chain);
+		advisor.after(buildResponse("answer two"), chain);
+
+		assertThat(this.sessionService.getEvents(this.sessionId, EventFilter.all())).hasSize(4);
+	}
+
+	@Test
+	void sameRunIdRetryStillDedupesWhenConfiguredWithARunIdKey() {
+		SessionMemoryAdvisor advisor = advisorWith(
+				new IdempotentSessionEventIdGenerator(RUN_ID_KEY, SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY));
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		advisor.before(buildRequestWithRunId("hello", "run-1"), chain);
+		advisor.after(buildResponseWithRunId("the answer", "run-1"), chain);
+		advisor.before(buildRequestWithRunId("hello", "run-1"), chain);
+		advisor.after(buildResponseWithRunId("the answer", "run-1"), chain);
+
+		assertThat(this.sessionService.getEvents(this.sessionId, EventFilter.all())).hasSize(2);
+	}
+
+	@Test
+	void differentRunIdWithIdenticalContentIsNotTreatedAsACollision() {
+		SessionMemoryAdvisor advisor = advisorWith(
+				new IdempotentSessionEventIdGenerator(RUN_ID_KEY, SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY));
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		advisor.before(buildRequestWithRunId("hello", "run-1"), chain);
+		advisor.after(buildResponseWithRunId("the answer", "run-1"), chain);
+		advisor.before(buildRequestWithRunId("hello", "run-2"), chain);
+		advisor.after(buildResponseWithRunId("the answer", "run-2"), chain);
+
+		assertThat(this.sessionService.getEvents(this.sessionId, EventFilter.all())).hasSize(4);
+	}
+
+	@Test
+	void replayedToolCallResponseReusesTheModelAssignedIdAndDoesNotDuplicate() {
+		SessionMemoryAdvisor advisor = advisorWith(new IdempotentSessionEventIdGenerator());
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		AssistantMessage toolCallMessage = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{}")))
+			.build();
+		ChatClientResponse response = ChatClientResponse.builder()
+			.chatResponse(ChatResponse.builder().generations(List.of(new Generation(toolCallMessage))).build())
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId))
+			.build();
+
+		// Replaying the exact same tool-call response (e.g. a resumed process re-deriving
+		// the same model turn) must not duplicate the tool-call event.
+		advisor.after(response, chain);
+		advisor.after(response, chain);
+
+		assertThat(this.sessionService.getEvents(this.sessionId, EventFilter.all())).hasSize(1);
+	}
+
+	private SessionMemoryAdvisor advisorWith(IdempotentSessionEventIdGenerator generator) {
+		return SessionMemoryAdvisor.builder(this.sessionService)
+			.requestEventIdGenerator(generator)
+			.responseEventIdGenerator(generator)
+			.build();
+	}
+
+	private ChatClientRequest buildRequest(String userText) {
+		Prompt prompt = new Prompt(List.of(new UserMessage(userText)));
+		return ChatClientRequest.builder()
+			.prompt(prompt)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId))
+			.build();
+	}
+
+	private ChatClientRequest buildRequestWithRunId(String userText, String runId) {
+		Prompt prompt = new Prompt(List.of(new UserMessage(userText)));
+		return ChatClientRequest.builder()
+			.prompt(prompt)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId, RUN_ID_KEY, runId))
+			.build();
+	}
+
+	private ChatClientResponse buildResponse(String assistantText) {
+		ChatResponse chatResponse = ChatResponse.builder()
+			.generations(List.of(new Generation(new AssistantMessage(assistantText))))
+			.build();
+		return ChatClientResponse.builder()
+			.chatResponse(chatResponse)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId))
+			.build();
+	}
+
+	private ChatClientResponse buildResponseWithRunId(String assistantText, String runId) {
+		ChatResponse chatResponse = ChatResponse.builder()
+			.generations(List.of(new Generation(new AssistantMessage(assistantText))))
+			.build();
+		return ChatClientResponse.builder()
+			.chatResponse(chatResponse)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId, RUN_ID_KEY, runId))
+			.build();
+	}
+
+}

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
@@ -556,6 +556,54 @@ class SessionMemoryAdvisorIT {
 		assertThat(this.sessionService.getEvents(this.sessionId)).isEmpty();
 	}
 
+	// --- Pluggable event id generation ---
+
+	@Test
+	void requestEventIdGeneratorMakesRetriedBeforeCallIdempotent() {
+		// A fixed id simulates a caller supplying a deterministic id for retry safety
+		// (e.g. derived from an upstream durability layer's own idempotency key).
+		SessionMemoryAdvisor deterministicAdvisor = SessionMemoryAdvisor.builder(this.sessionService)
+			.requestEventIdGenerator((request, message) -> "fixed-request-id")
+			.build();
+
+		ChatClientRequest request = buildRequest(this.sessionId, "hello");
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		deterministicAdvisor.before(request, chain);
+		deterministicAdvisor.before(request, chain);
+
+		assertThat(this.sessionService.getEvents(this.sessionId)).hasSize(1);
+	}
+
+	@Test
+	void responseEventIdGeneratorMakesRetriedAfterCallIdempotent() {
+		SessionMemoryAdvisor deterministicAdvisor = SessionMemoryAdvisor.builder(this.sessionService)
+			.responseEventIdGenerator((response, message) -> "fixed-response-id")
+			.build();
+
+		ChatClientResponse response = buildResponse(this.sessionId, "answer");
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		deterministicAdvisor.after(response, chain);
+		deterministicAdvisor.after(response, chain);
+
+		assertThat(this.sessionService.getEvents(this.sessionId)).hasSize(1);
+	}
+
+	@Test
+	void defaultEventIdGeneratorsProduceDistinctIdsAcrossRepeatedCalls() {
+		// Regression guard: without a custom generator, retried calls with identical
+		// content must NOT be deduped -- the random default must keep producing fresh
+		// ids, matching the pre-existing appendMessage() behaviour.
+		ChatClientRequest request = buildRequest(this.sessionId, "hello");
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		this.advisor.before(request, chain);
+		this.advisor.before(request, chain);
+
+		assertThat(this.sessionService.getEvents(this.sessionId)).hasSize(2);
+	}
+
 	// --- Builder validation ---
 
 	@Test


### PR DESCRIPTION
A retried appendEvent always created a duplicate event: ids defaulted to random, and SessionMemoryAdvisor's only write path (appendMessage) had no way to supply a deterministic one instead.

- appendEvent: a duplicate SessionEvent#getId() is now a no-op instead of an error (Jdbc) or a silent duplicate (InMemory).
- New SessionEventRequestIdGenerator/SessionEventResponseIdGenerator SPI, wired into SessionMemoryAdvisor.Builder; before()/after() now call appendEvent directly with the generated id. Defaults preserve today's random-id behavior.
- New IdempotentSessionEventIdGenerator: reuses the model's own ToolCall/ToolResponse ids where present, else hashes a configurable context-key fingerprint (session id by default, optionally a run id too). Stays correct regardless of how many advisors end up wrapping SessionMemoryAdvisor.
- Adds repository, advisor, and generator tests covering the above.