### PR TITLE
Prevent duplicate prompt history when Memory Advisor nests in a tool-calling or other loop

### DIFF
--- a/docs/session-management/chat-client.md
+++ b/docs/session-management/chat-client.md
@@ -70,13 +70,27 @@ ChatClient client = ChatClient.builder(chatModel)
     Setting only one of `compactionTrigger` or `compactionStrategy` throws
     `IllegalStateException`. Set both or neither.
 
-!!! note "Default advisor order"
+!!! note "Default advisor order — nested inside the tool-calling loop"
     The default order is `Ordered.HIGHEST_PRECEDENCE + 1000` (≈ `Integer.MIN_VALUE + 1000`),
-    giving `SessionMemoryAdvisor` higher precedence than `ToolAdvisor` (order `300`).
-    Higher precedence means `before()` runs first and `after()` runs last, so
-    `SessionMemoryAdvisor` wraps the tool advisor — tool results are fully resolved before
-    the session write in `after()`. Override with `.order(n)` if your pipeline requires a
-    different position.
+    numerically higher — i.e. **lower precedence** — than `ToolCallingAdvisor`'s default
+    order (`HIGHEST_PRECEDENCE + 300`). Advisors are sorted ascending by order and the
+    lowest value wraps everything after it, so at default orders `ToolCallingAdvisor` wraps
+    `SessionMemoryAdvisor`, not the other way round: `SessionMemoryAdvisor.before()`/`after()`
+    run once per round of the tool-call loop, not once per outer call.
+
+    This is deliberate and safe. From round 2 onward, the prompt handed to `before()`
+    already contains the current turn's messages (persisted by the previous round), and
+    `before()` detects that its retrieved history is already a contiguous run in that
+    prompt and skips prepending it again — so no duplicate messages reach the model.
+    Persisted events aren't duplicated either: only the round's trailing
+    user/tool-response message and the model's own reply are ever appended. This means
+    `SessionMemoryAdvisor` nests correctly under a default-configured `ToolCallingAdvisor`
+    with its internal conversation history left **enabled** — you don't need
+    `.disableInternalConversationHistory()` to avoid duplication.
+
+    Override with `.order(n)` (a value lower than the tool-calling advisor's) if your
+    pipeline instead needs `SessionMemoryAdvisor` to wrap the loop and write to the
+    session only once, after tool results are fully resolved.
 
 ---
 

--- a/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
+++ b/spring-ai-session/src/main/java/org/springframework/ai/session/advisor/SessionMemoryAdvisor.java
@@ -86,6 +86,20 @@ import org.springframework.util.Assert;
  * durability layer's own idempotency key) to make a retried append an idempotent no-op
  * instead, via {@code SessionRepository.appendEvent}'s id-based replay contract.
  *
+ * <p>
+ * <strong>Nesting inside a tool-calling loop:</strong> an advisor such as
+ * {@code ToolCallingAdvisor} that implements its own tool-call loop re-enters the rest of
+ * the advisor chain once per round, so if this advisor's order places it deeper in the
+ * chain than the looping advisor, {@code before()}/{@code after()} run once per round too.
+ * From round 2 onward the prompt passed in already carries this turn's messages (they were
+ * persisted to the session by the previous round), so {@code before()} detects that the
+ * session history it just retrieved is already a contiguous run within the prompt and skips
+ * prepending it again -- avoiding duplicate messages in the prompt sent to the model. Actual
+ * persistence is unaffected by nesting depth: only the current turn's trailing
+ * user/tool-response message and the model's own reply are ever appended, and with a
+ * deterministic {@link IdempotentSessionEventIdGenerator} configured, a re-derived id makes
+ * a repeated append of the same message an idempotent no-op rather than a duplicate event.
+ *
  * @author Christian Tzolov
  * @since 2.0.0
  */
@@ -202,8 +216,21 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 		List<SessionEvent> events = this.sessionService.getEvents(sessionId, eventFilter);
 		List<Message> history = events.stream().map(SessionEvent::getMessage).toList();
 
-		List<Message> combined = new ArrayList<>(history);
-		combined.addAll(request.prompt().getInstructions());
+		// 2.1. Skip re-prepending history that the prompt already carries. This
+		// happens when this advisor is nested inside a looping advisor -- e.g. a
+		// ToolCallingAdvisor with an order placing it deeper in the chain (see the
+		// order Javadoc on the Builder) -- whose tool-call loop re-enters before()
+		// once per round. From round 2 onward, request.prompt().getInstructions()
+		// already contains this turn's user/assistant/tool messages, persisted to
+		// the session by the previous round's before()/after(); without this guard
+		// getEvents() would return that same prefix and it would be prepended a
+		// second time.
+		List<Message> promptMessages = request.prompt().getInstructions();
+		List<Message> combined = new ArrayList<>();
+		if (!isHistoryAlreadyInPrompt(promptMessages, history)) {
+			combined.addAll(history);
+		}
+		combined.addAll(promptMessages);
 
 		// 3. Ensure all system messages appear first (preserving their relative order).
 		// A single pass collects every SystemMessage, removes them in place, then
@@ -290,6 +317,39 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 	}
 
 	/**
+	 * Returns {@code true} if {@code history} already occurs as a contiguous run
+	 * somewhere in {@code promptMessages}, in which case prepending it again would
+	 * duplicate it. Meant to guard against the same class of duplication when a memory
+	 * advisor is re-entered inside a tool-calling loop.
+	 */
+	private static boolean isHistoryAlreadyInPrompt(List<Message> promptMessages, List<Message> history) {
+		if (history.isEmpty()) {
+			return true;
+		}
+		if (promptMessages.size() < history.size()) {
+			return false;
+		}
+		for (int offset = 0; offset <= promptMessages.size() - history.size(); offset++) {
+			if (startsWith(promptMessages, history, offset)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean startsWith(List<Message> messages, List<Message> prefix, int offset) {
+		if (messages.size() - offset < prefix.size()) {
+			return false;
+		}
+		for (int i = 0; i < prefix.size(); i++) {
+			if (!messages.get(i + offset).equals(prefix.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Returns {@code true} if the message should be persisted to the session, delegating
 	 * to the configured {@link MessageFilter}. Rejected messages are logged and not
 	 * replayed on later requests.
@@ -313,9 +373,13 @@ public final class SessionMemoryAdvisor implements BaseAdvisor, MemoryAdvisor {
 
 		private String defaultUserId = "default-user";
 
-		// Higher precedence than default ToolCallingAdvisor: before() runs first, after()
-		// runs last, so tool results are fully resolved before being written to session
-		// history.
+		// Deliberately higher (lower-precedence) than ToolCallingAdvisor's default order
+		// (HIGHEST_PRECEDENCE + 300): with ascending order sort, the lower value runs
+		// outer, so this places SessionMemoryAdvisor nested inside a default-configured
+		// ToolCallingAdvisor's tool-call loop rather than wrapping it -- before()/after()
+		// then run once per round, which is what the isHistoryAlreadyInPrompt() guard in
+		// before() is built to tolerate (see the class Javadoc "Nesting inside a
+		// tool-calling loop" section).
 		private int order = Ordered.HIGHEST_PRECEDENCE + 1000;
 
 		private Scheduler scheduler = BaseAdvisor.DEFAULT_SCHEDULER;

--- a/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
+++ b/spring-ai-session/src/test/java/org/springframework/ai/session/advisor/SessionMemoryAdvisorIT.java
@@ -173,6 +173,50 @@ class SessionMemoryAdvisorIT {
 	}
 
 	@Test
+	void beforeSkipsDuplicatingHistoryWhenNestedInsideToolCallingLoop() {
+		// Simulates a looping advisor such as ToolCallingAdvisor re-entering the chain
+		// once per tool-call round (see the class Javadoc "Nesting inside a
+		// tool-calling loop" section). From round 2 onward, the incoming prompt
+		// already carries this turn's messages -- the same messages round 1's
+		// before()/after() just persisted -- so before() must not prepend them again.
+		AdvisorChain chain = mock(AdvisorChain.class);
+
+		UserMessage userMessage = new UserMessage("What is the weather in Paris?");
+		AssistantMessage toolCallMessage = AssistantMessage.builder()
+			.toolCalls(
+					List.of(new AssistantMessage.ToolCall("call-1", "function", "get_weather", "{\"city\":\"Paris\"}")))
+			.build();
+
+		// Round 1: only the user message is in the prompt.
+		this.advisor.before(buildRequest(this.sessionId, userMessage.getText()), chain);
+		this.advisor.after(buildResponseFromMessages(this.sessionId, toolCallMessage), chain);
+
+		// Round 2: the prompt already contains this turn's user message and tool-call
+		// message, plus the fresh tool response.
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(
+					List.of(new ToolResponseMessage.ToolResponse("call-1", "get_weather", "15 degrees and sunny")))
+			.build();
+		Prompt round2Prompt = new Prompt(List.of(userMessage, toolCallMessage, toolResponse));
+		ChatClientRequest round2Request = ChatClientRequest.builder()
+			.prompt(round2Prompt)
+			.context(Map.of(SessionMemoryAdvisor.SESSION_ID_CONTEXT_KEY, this.sessionId))
+			.build();
+
+		ChatClientRequest modified = this.advisor.before(round2Request, chain);
+
+		// No duplication: the user message and tool-call message must not appear twice.
+		List<Message> instructions = modified.prompt().getInstructions();
+		assertThat(instructions).containsExactly(userMessage, toolCallMessage, toolResponse);
+
+		// The tool response is persisted for the first time; the user/assistant pair
+		// from round 1 is not persisted again.
+		List<SessionEvent> events = this.sessionService.getEvents(this.sessionId);
+		assertThat(events).hasSize(3);
+		assertThat(events.get(2).getMessage()).isEqualTo(toolResponse);
+	}
+
+	@Test
 	void compactionIsTriggeredAfterThreshold() {
 		// Wire advisor with a very low compaction threshold (1 turn) and small window
 		SessionMemoryAdvisor compactingAdvisor = SessionMemoryAdvisor.builder(this.sessionService)


### PR DESCRIPTION
Ported the isMemoryAlreadyInPrompt guard from spring-ai's MessageChatMemoryAdvisor (GH-6211): before() now skips re-prepending session history that's already a contiguous run in the prompt, which happens once ToolCallingAdvisor's loop re-enters the chain per round. 
Also fixes the reference doc